### PR TITLE
Add DevNomads DNS provider plugin for lexicon

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -22,6 +22,7 @@ lexicon/providers/cloudxns.py       @zh99998
 lexicon/providers/conoha.py         @kaz
 lexicon/providers/constellix.py     @pmkane
 lexicon/providers/ddns.py           @trinity-1686a
+lexicon/providers/devnomads.py      @loekg
 lexicon/providers/digitalocean.py   @analogj @foxwoods369
 lexicon/providers/dinahosting.py    @iperurena
 lexicon/providers/directadmin.py    @bauglir

--- a/README.rst
+++ b/README.rst
@@ -83,37 +83,37 @@ Lexicon currently supports 87 providers:
 +-----------------+-----------------+-----------------+-----------------+-----------------+
 | cloudns_        | cloudxns_       | conoha_         | constellix_     | ddns_           |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| digitalocean_   | dinahosting_    | directadmin_    | dnsimple_       | dnsmadeeasy_    |
+| devnomads_      | digitalocean_   | dinahosting_    | directadmin_    | dnsimple_       |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| dnspark_        | dnspod_         | dnsservices_    | dreamhost_      | duckdns_        |
+| dnsmadeeasy_    | dnspark_        | dnspod_         | dnsservices_    | dreamhost_      |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| dynu_           | easydns_        | easyname_       | euserv_         | exoscale_       |
+| duckdns_        | dynu_           | easydns_        | easyname_       | euserv_         |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| flexibleengine_ | gandi_          | gehirn_         | glesys_         | godaddy_        |
+| exoscale_       | flexibleengine_ | gandi_          | gehirn_         | glesys_         |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| googleclouddns_ | gransy_         | gratisdns_      | henet_          | hetzner_        |
+| godaddy_        | googleclouddns_ | gransy_         | gratisdns_      | henet_          |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| hostingde_      | hover_          | infoblox_       | infomaniak_     | internetbs_     |
+| hetzner_        | hostingde_      | hover_          | infoblox_       | infomaniak_     |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| inwx_           | ionos_          | joker_          | linode_         | linode4_        |
+| internetbs_     | inwx_           | ionos_          | joker_          | linode_         |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| localzone_      | luadns_         | memset_         | misaka_         | mythicbeasts_   |
+| linode4_        | localzone_      | luadns_         | memset_         | misaka_         |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| namecheap_      | namecom_        | namesilo_       | netcup_         | nfsn_           |
+| mythicbeasts_   | namecheap_      | namecom_        | namesilo_       | netcup_         |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| njalla_         | nsone_          | oci_            | onapp_          | online_         |
+| nfsn_           | njalla_         | nsone_          | oci_            | onapp_          |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| ovh_            | plesk_          | pointhq_        | porkbun_        | powerdns_       |
+| online_         | ovh_            | plesk_          | pointhq_        | porkbun_        |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| qcloud_         | rackspace_      | rage4_          | rcodezero_      | regfish_        |
+| powerdns_       | qcloud_         | rackspace_      | rage4_          | rcodezero_      |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| route53_        | safedns_        | sakuracloud_    | softlayer_      | timeweb_        |
+| regfish_        | route53_        | safedns_        | sakuracloud_    | softlayer_      |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| transip_        | ultradns_       | valuedomain_    | vercel_         | vultr_          |
+| timeweb_        | transip_        | ultradns_       | valuedomain_    | vercel_         |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| webgo_          | wedos_          | yandex_         | yandexcloud_    | zeit_           |
+| vultr_          | webgo_          | wedos_          | yandex_         | yandexcloud_    |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
-| zilore_         | zonomi_         |                 |                 |                 |
+| zeit_           | zilore_         | zonomi_         |                 |                 |
 +-----------------+-----------------+-----------------+-----------------+-----------------+
 
 .. tag: providers-table-end
@@ -128,6 +128,7 @@ Lexicon currently supports 87 providers:
 .. _conoha: https://www.conoha.jp/docs/
 .. _constellix: https://api-docs.constellix.com/?version=latest
 .. _ddns: https://www.rfc-editor.org/rfc/rfc2136
+.. _devnomads: https://api.devnomads.nl/api/documentation
 .. _digitalocean: https://developers.digitalocean.com/documentation/v2/#create-a-new-domain
 .. _dinahosting: https://en.dinahosting.com/api
 .. _directadmin: https://www.directadmin.com/features.php?id=504

--- a/README.rst
+++ b/README.rst
@@ -76,7 +76,7 @@ Only DNS providers who have an API can be supported by `lexicon`.
 
 .. tag: providers-table-begin
 
-Lexicon currently supports 87 providers:
+Lexicon currently supports 88 providers:
 
 +-----------------+-----------------+-----------------+-----------------+-----------------+
 | aliyun_         | arvancloud_     | aurora_         | azure_          | cloudflare_     |

--- a/docs/providers/devnomads.rst
+++ b/docs/providers/devnomads.rst
@@ -1,0 +1,2 @@
+devnomads
+    * ``auth_token`` Specify token for authentication

--- a/src/lexicon/_private/providers/devnomads.py
+++ b/src/lexicon/_private/providers/devnomads.py
@@ -7,7 +7,7 @@ API Docs: https://api.devnomads.nl/api/documentation#/Dns
 
 Implementation notes:
 The DevNomads API basically implements the PowerDNS API but applies client
-specific authentication and filtering. For docs and usage, see PowerDNS.
+specific authentication and filtering.
 """
 
 import json
@@ -35,7 +35,7 @@ class Provider(BaseProvider):
 
     @staticmethod
     def configure_parser(parser: ArgumentParser) -> None:
-        parser.add_argument("--bearer-token", help="Bearer token.")
+        parser.add_argument("--auth-token", help="Auth token.")
 
     def __init__(self, config):
         super(Provider, self).__init__(config)
@@ -45,8 +45,8 @@ class Provider(BaseProvider):
         if self.api_endpoint.endswith("/"):
             self.api_endpoint = self.api_endpoint[:-1]
 
-        self.bearer_token = self._get_provider_option("bearer_token")
-        if not self.bearer_token:
+        self.auth_token = self._get_provider_option("auth_token")
+        if not self.auth_token:
             raise DevNomadsProviderError(
                 "DevNomads auth token not defined (auth_token)"
             )
@@ -216,7 +216,7 @@ class Provider(BaseProvider):
             params=query_params,
             data=json.dumps(data),
             headers={
-                "Authorization": f"Bearer {self.bearer_token}",
+                "Authorization": f"Bearer {self.auth_token}",
                 "Content-Type": "application/json",
             },
         )

--- a/src/lexicon/_private/providers/devnomads.py
+++ b/src/lexicon/_private/providers/devnomads.py
@@ -1,0 +1,234 @@
+"""
+Lexicon DevNomads Provider
+
+Author: Loek Geleijn, 2025
+
+API Docs: https://api.devnomads.nl/api/documentation#/Dns
+
+Implementation notes:
+The DevNomads API basically implements the PowerDNS API but applies client
+specific authentication and filtering. For docs and usage, see PowerDNS.
+"""
+
+import json
+import logging
+from argparse import ArgumentParser
+from typing import List
+
+import requests
+
+from lexicon.interfaces import Provider as BaseProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DevNomadsProviderError(Exception):
+    """Generic DevNomads exception"""
+
+
+class Provider(BaseProvider):
+    """Provider class for DevNomads"""
+
+    @staticmethod
+    def get_nameservers() -> List[str]:
+        return []
+
+    @staticmethod
+    def configure_parser(parser: ArgumentParser) -> None:
+        parser.add_argument("--bearer-token", help="Bearer token.")
+
+    def __init__(self, config):
+        super(Provider, self).__init__(config)
+
+        self.api_endpoint = "https://api.devnomads.nl/services/dns"
+
+        if self.api_endpoint.endswith("/"):
+            self.api_endpoint = self.api_endpoint[:-1]
+
+        self.bearer_token = self._get_provider_option("bearer_token")
+        if not self.bearer_token:
+            raise DevNomadsProviderError(
+                "DevNomads auth token not defined (auth_token)"
+            )
+
+        self._zone_data = None
+
+    def zone_data(self):
+        """Get zone data"""
+        if self._zone_data is None:
+            self._zone_data = self._get(
+                "/zones/" + self._ensure_dot(self.domain)
+            ).json()
+        return self._zone_data
+
+    def authenticate(self):
+        self.zone_data()
+        self.domain_id = self.domain
+
+    def cleanup(self) -> None:
+        pass
+
+    def _make_identifier(self, rtype, name, content):
+        return f"{rtype}/{name}={content}"
+
+    def _parse_identifier(self, identifier):
+        parts = identifier.split("/")
+        rtype = parts[0]
+        parts = parts[1].split("=")
+        name = parts[0]
+        content = "=".join(parts[1:])
+        return rtype, name, content
+
+    def list_records(self, rtype=None, name=None, content=None):
+        records = []
+        for rrset in self.zone_data()["rrsets"]:
+            if (
+                name is None or self._fqdn_name(rrset["name"]) == self._fqdn_name(name)
+            ) and (rtype is None or rrset["type"] == rtype):
+                for record in rrset["records"]:
+                    if content is None or record["content"] == self._clean_content(
+                        rtype, content
+                    ):
+                        records.append(
+                            {
+                                "type": rrset["type"],
+                                "name": self._full_name(rrset["name"]),
+                                "ttl": rrset["ttl"],
+                                "content": self._unclean_content(
+                                    rrset["type"], record["content"]
+                                ),
+                                "id": self._make_identifier(
+                                    rrset["type"], rrset["name"], record["content"]
+                                ),
+                            }
+                        )
+        LOGGER.debug(f"list_records: {records}")
+        return records
+
+    def _clean_content(self, rtype, content):
+        if rtype in ("TXT", "LOC"):
+            if content[0] != '"':
+                content = '"' + content
+            if content[-1] != '"':
+                content += '"'
+        elif rtype == "CNAME":
+            content = self._fqdn_name(content)
+        return content
+
+    def _unclean_content(self, rtype, content):
+        if rtype in ("TXT", "LOC"):
+            content = content.strip('"')
+        elif rtype == "CNAME":
+            content = self._full_name(content)
+        return content
+
+    def create_record(self, rtype, name, content):
+        rname = self._fqdn_name(name)
+        newcontent = self._clean_content(rtype, content)
+
+        updated_data = {
+            "name": rname,
+            "type": rtype,
+            "records": [],
+            "ttl": self._get_lexicon_option("ttl") or 600,
+            "changetype": "REPLACE",
+        }
+
+        updated_data["records"].append({"content": newcontent, "disabled": False})
+
+        for rrset in self.zone_data()["rrsets"]:
+            if rrset["name"] == rname and rrset["type"] == rtype:
+                updated_data["ttl"] = rrset["ttl"]
+
+                for record in rrset["records"]:
+                    if record["content"] != newcontent:
+                        updated_data["records"].append(
+                            {
+                                "content": record["content"],
+                                "disabled": record["disabled"],
+                            }
+                        )
+                break
+
+        request = {"rrsets": [updated_data]}
+        LOGGER.debug(f"request: {requests}")
+
+        self._patch("/zones/" + self._ensure_dot(self.domain), data=request)
+        self._zone_data = None
+        return True
+
+    def delete_record(self, identifier=None, rtype=None, name=None, content=None):
+        if identifier is not None:
+            rtype, name, content = self._parse_identifier(identifier)
+
+        LOGGER.debug(f"delete {rtype} {name} {content}")
+        if rtype is None or name is None:
+            raise Exception("Must specify at least both rtype and name")
+
+        for rrset in self.zone_data()["rrsets"]:
+            if rrset["type"] == rtype and self._fqdn_name(
+                rrset["name"]
+            ) == self._fqdn_name(name):
+                update_data = rrset
+
+                if "comments" in update_data:
+                    del update_data["comments"]
+
+                if content is None:
+                    update_data["records"] = []
+                    update_data["changetype"] = "DELETE"
+                else:
+                    new_record_list = []
+                    for record in update_data["records"]:
+                        if (
+                            self._clean_content(rrset["type"], content)
+                            != record["content"]
+                        ):
+                            new_record_list.append(record)
+
+                    update_data["records"] = new_record_list
+                    update_data["changetype"] = "REPLACE"
+                break
+
+        request = {"rrsets": [update_data]}
+        LOGGER.debug(f"request: {request}")
+
+        self._patch("/zones/" + self._ensure_dot(self.domain), data=request)
+
+        self._zone_data = None
+        return True
+
+    def update_record(self, identifier, rtype=None, name=None, content=None):
+        self.delete_record(identifier)
+        return self.create_record(rtype, name, content)
+
+    def _patch(self, url="/", data=None, query_params=None):
+        return self._request("PATCH", url, data=data, query_params=query_params)
+
+    def _request(self, action="GET", url="/", data=None, query_params=None):
+        if data is None:
+            data = {}
+        if query_params is None:
+            query_params = {}
+        response = requests.request(
+            action,
+            self.api_endpoint + url,
+            params=query_params,
+            data=json.dumps(data),
+            headers={
+                "Authorization": f"Bearer {self.bearer_token}",
+                "Content-Type": "application/json",
+            },
+        )
+        LOGGER.debug(f"response: {response.text}")
+        response.raise_for_status()
+        return response
+
+    @classmethod
+    def _ensure_dot(cls, text):
+        """
+        This function makes sure a string contains a dot at the end
+        """
+        if text.endswith("."):
+            return text
+        return text + "."

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_authenticate.yaml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [],
+        "serial": 0, "soa_edit": "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '351'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,46 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/thisisadomainidonotown.com
+  response:
+    body:
+      string: '{"error": "Could not find domain ''thisisadomainidonotown.com.''"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '64'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 422
+      message: Unprocessable Entity
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,92 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [],
+        "serial": 0, "soa_edit": "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '351'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "localhost.example.nl.", "type": "A", "records":
+      [{"content": "127.0.0.1", "disabled": false}], "ttl": 3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '164'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,95 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '492'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "docs.example.nl.", "type": "CNAME", "records":
+      [{"content": "docs.example.com.example.nl.", "disabled": false}], "ttl":
+      3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '190'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,97 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "docs.example.nl.",
+        "records": [{"content": "docs.example.com.example.nl.", "disabled":
+        false}], "ttl": 3600, "type": "CNAME"}], "serial": 0, "soa_edit": "", "soa_edit_api":
+        "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '661'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.fqdn.example.nl.", "type":
+      "TXT", "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+      3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "docs.example.nl.",
+        "records": [{"content": "docs.example.com.example.nl.", "disabled":
+        false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name": "_acme-challenge.fqdn.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}], "serial": 0, "soa_edit": "", "soa_edit_api": "", "url":
+        "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '826'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.full.example.nl.", "type":
+      "TXT", "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+      3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,101 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "docs.example.nl.",
+        "records": [{"content": "docs.example.com.example.nl.", "disabled":
+        false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name": "_acme-challenge.fqdn.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}], "serial": 0, "soa_edit": "", "soa_edit_api": "", "url":
+        "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '991'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.test.example.nl.", "type":
+      "TXT", "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+      3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,207 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "docs.example.nl.",
+        "records": [{"content": "docs.example.com.example.nl.", "disabled":
+        false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name": "_acme-challenge.fqdn.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}], "serial": 0, "soa_edit": "", "soa_edit_api": "", "url":
+        "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1156'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.createrecordset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken1\"", "disabled": false}],
+      "ttl": 3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '198'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "docs.example.nl.",
+        "records": [{"content": "docs.example.com.example.nl.", "disabled":
+        false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name": "_acme-challenge.fqdn.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.full.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}], "serial": 0, "soa_edit": "", "soa_edit_api": "", "url":
+        "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1333'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.createrecordset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken2\"", "disabled": false},
+      {"content": "\"challengetoken1\"", "disabled": false}], "ttl": 3600, "changetype":
+      "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '253'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,271 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1388'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.noop.example.nl.", "type":
+      "TXT", "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+      3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.noop.example.nl.", "type":
+      "TXT", "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+      3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,274 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testfilt.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "delete.testfilt.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1713'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testfilt.example.nl.", "records":
+      [], "ttl": 3600, "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,274 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testfqdn.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "delete.testfqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1713'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testfqdn.example.nl.", "records":
+      [], "ttl": 3600, "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,274 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testfull.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "delete.testfull.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1713'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testfull.example.nl.", "records":
+      [], "ttl": 3600, "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '129'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,274 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testid.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "delete.testid.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1711'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "delete.testid.example.nl.", "records": [],
+      "ttl": 3600, "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,386 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1553'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.deleterecordinset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken1\"", "disabled": false}],
+      "ttl": 3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1732'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.deleterecordinset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken2\"", "disabled": false},
+      {"content": "\"challengetoken1\"", "disabled": false}], "ttl": 3600, "changetype":
+      "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1787'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.deleterecordinset.example.nl.",
+      "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl": 3600,
+      "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '200'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1732'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,391 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1732'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.deleterecordset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken1\"", "disabled": false}],
+      "ttl": 3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '198'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1909'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.deleterecordset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken2\"", "disabled": false},
+      {"content": "\"challengetoken1\"", "disabled": false}], "ttl": 3600, "changetype":
+      "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '253'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1964'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.deleterecordset.example.nl.",
+      "records": [], "ttl": 3600, "type": "TXT", "changetype": "DELETE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '144'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1732'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,174 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1732'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "ttl.fqdn.example.nl.", "type": "TXT", "records":
+      [{"content": "\"ttlshouldbe3600\"", "disabled": false}], "ttl": 3600, "changetype":
+      "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '175'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1886'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,291 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '1886'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.listrecordset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken1\"", "disabled": false}],
+      "ttl": 3600, "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.createrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2061'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "_acme-challenge.listrecordset.example.nl.",
+      "type": "TXT", "records": [{"content": "\"challengetoken2\"", "disabled": false},
+      {"content": "\"challengetoken1\"", "disabled": false}], "ttl": 3600, "changetype":
+      "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '251'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2116'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,184 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2116'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "random.fqdntest.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2276'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,188 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2276'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "random.fulltest.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2436'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,74 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2436'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,192 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2436'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "random.test.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '177'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2592'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2592'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,357 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2592'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "orig.test.example.nl.", "type": "TXT", "records":
+      [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600, "changetype":
+      "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '175'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "orig.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2746'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "orig.test.example.nl.", "records": [], "ttl":
+      3600, "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2592'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "updated.test.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '178'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,363 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "updated.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2749'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "orig.testfqdn.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "updated.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "orig.testfqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2907'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "orig.testfqdn.example.nl.", "records": [],
+      "ttl": 3600, "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "updated.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2749'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "updated.testfqdn.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/devnomads/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,369 @@
+interactions:
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "updated.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "updated.testfqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2910'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "orig.testfull.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '179'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "updated.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "updated.testfqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "orig.testfull.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '3068'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "orig.testfull.example.nl.", "records": [],
+      "ttl": 3600, "type": "TXT", "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: GET
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: '{"account": "", "api_rectify": false, "dnssec": false, "id": "example.nl.",
+        "kind": "Master", "last_check": 0, "masters": [], "name": "example.nl.",
+        "notified_serial": 0, "nsec3narrow": false, "nsec3param": "", "rrsets": [{"comments":
+        [], "name": "localhost.example.nl.", "records": [{"content": "127.0.0.1",
+        "disabled": false}], "ttl": 3600, "type": "A"}, {"comments": [], "name": "random.fqdntest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.fulltest.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "random.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "updated.test.example.nl.",
+        "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.deleterecordinset.example.nl.",
+        "records": [{"content": "\"challengetoken2\"", "disabled": false}], "ttl":
+        3600, "type": "TXT"}, {"comments": [], "name": "_acme-challenge.listrecordset.example.nl.",
+        "records": [{"content": "\"challengetoken1\"", "disabled": false}, {"content":
+        "\"challengetoken2\"", "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments":
+        [], "name": "_acme-challenge.createrecordset.example.nl.", "records":
+        [{"content": "\"challengetoken1\"", "disabled": false}, {"content": "\"challengetoken2\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "docs.example.nl.", "records": [{"content": "docs.example.com.example.nl.",
+        "disabled": false}], "ttl": 3600, "type": "CNAME"}, {"comments": [], "name":
+        "_acme-challenge.noop.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "updated.testfqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "ttl.fqdn.example.nl.", "records": [{"content": "\"ttlshouldbe3600\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.fqdn.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}, {"comments": [], "name":
+        "_acme-challenge.full.example.nl.", "records": [{"content": "\"challengetoken\"",
+        "disabled": false}], "ttl": 3600, "type": "TXT"}], "serial": 0, "soa_edit":
+        "", "soa_edit_api": "", "url": "/services/dns/zones/example.nl."}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '2910'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Content-Type:
+      - application/json
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"rrsets": [{"name": "updated.testfull.example.nl.", "type": "TXT",
+      "records": [{"content": "\"challengetoken\"", "disabled": false}], "ttl": 3600,
+      "changetype": "REPLACE"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.21.0
+    method: PATCH
+    uri: https://api.devnomads.nl/services/dns/zones/example.nl.
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Connection:
+      - close
+      Content-Length:
+      - '0'
+      Content-Security-Policy:
+      - default-src 'self'; style-src 'self' 'unsafe-inline'
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/providers/test_devnomads.py
+++ b/tests/providers/test_devnomads.py
@@ -1,0 +1,22 @@
+"""Integration tests for PowerDNS"""
+
+from unittest import TestCase
+
+import pytest
+from integration_tests import IntegrationTestsV2
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class PowerdnsProviderTests(TestCase, IntegrationTestsV2):
+    """TestCase for DevNomads"""
+
+    provider_name = "devnomads"
+    domain = "example.com"
+
+    def _filter_headers(self):
+        return ["Authorization"]
+
+    def _filter_post_data_parameters(self):
+        return ["bearer_token"]

--- a/tests/providers/test_devnomads.py
+++ b/tests/providers/test_devnomads.py
@@ -9,14 +9,17 @@ from integration_tests import IntegrationTestsV2
 # Hook into testing framework by inheriting unittest.TestCase and reuse
 # the tests which *each and every* implementation of the interface must
 # pass, by inheritance from integration_tests.IntegrationTests
-class PowerdnsProviderTests(TestCase, IntegrationTestsV2):
+class DevNomadsProviderTests(TestCase, IntegrationTestsV2):
     """TestCase for DevNomads"""
 
     provider_name = "devnomads"
-    domain = "example.com"
+    domain = "example.nl"
 
     def _filter_headers(self):
         return ["Authorization"]
 
-    def _filter_post_data_parameters(self):
-        return ["bearer_token"]
+    @pytest.mark.skip(reason="new test, missing recording")
+    def test_provider_when_calling_update_record_should_modify_record_name_specified(
+        self,
+    ):
+        return

--- a/tests/providers/test_devnomads.py
+++ b/tests/providers/test_devnomads.py
@@ -1,4 +1,4 @@
-"""Integration tests for PowerDNS"""
+"""Integration tests for DevNomads"""
 
 from unittest import TestCase
 


### PR DESCRIPTION
This PR adds a new DNS provider plugin for the [DevNomads](https://devnomads.nl) DNS api. The DevNomads API proxies requests to a PowerDNS based backend but applies client specific authentication and filtering. This code is a modified version of the existing PowerDNS provider.