### PR TITLE
Don't require IONOS API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## 3.20.1 - 19/12/2024
 ### Modified
 * Setup Docker entrypoint to run Lexicon by default
+* IONOS authentication is not required when using automatic detection of
+  registrar
 
 ## 3.20.0 - 12/12/2024
 ### Modified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ envlist = [ "cover", "lint" , "mypy" ]
 [tool.tox.env_run_base]
 runner = "uv-venv-lock-runner"
 with_dev = true
-uv_sync_flags =  [ "--python={env_python}" ]  # Fix until https://github.com/tox-dev/tox-uv/issues/110 is fixed
 extras = [ "full" ]
 setenv.PYTEST_ADDOPTS = "--numprocesses auto"
 setenv.PYTHONHASHSEED = "0"

--- a/src/lexicon/_private/providers/ionos.py
+++ b/src/lexicon/_private/providers/ionos.py
@@ -15,7 +15,6 @@ class Provider(BaseProvider):
     def configure_parser(parser):
         parser.add_argument(
             "--api-key",
-            required=True,
             help="IONOS api key: public prefix + period + key proper",
         )
 


### PR DESCRIPTION
IONOS API key is required when the automatic detection of provider is used, even if this registrar is not used. It fails with this error:
```
lexicon auto: error: the following arguments are required: --ionos-api-key
```

Remove this requirement, other providers don't set any variable as required.