### PR TITLE
replace deprecated `.findAll()` method with `.find_all()` (fixes #28)

### DIFF
--- a/src/lexicon/_private/providers/easyname.py
+++ b/src/lexicon/_private/providers/easyname.py
@@ -273,7 +273,7 @@ class Provider(BaseProvider):
                     rec["priority"] = (columns[3].contents[1].string or "").strip()
                     rec["ttl"] = (columns[4].contents[1].string or "").strip()
                     rec["id"] = ""
-                    for a in columns[5].findAll(
+                    for a in columns[5].find_all(
                         "a", class_="button button--transparent"
                     ):
                         rec["id"] = int(a["href"].rsplit("/", 1)[-1])
@@ -367,7 +367,7 @@ class Provider(BaseProvider):
         def _is_zone_tr(elm):
             return elm.name.lower() == "tr" and (elm.has_attr("class"))
 
-        rows = dns_table.findAll(_is_zone_tr)
+        rows = dns_table.find_all(_is_zone_tr)
         assert rows is not None and rows, "Could not find any DNS entries"
         return rows
 

--- a/src/lexicon/_private/providers/henet.py
+++ b/src/lexicon/_private/providers/henet.py
@@ -144,7 +144,7 @@ class Provider(BaseProvider):
         def is_dns_tr_type(klass):
             return klass and re.compile("dns_tr").search(klass)
 
-        records = html.findAll("tr", class_=is_dns_tr_type)
+        records = html.find_all("tr", class_=is_dns_tr_type)
 
         # If the tag couldn't be found, error, otherwise, return the value of the tag
         if records is None or not records:
@@ -153,7 +153,7 @@ class Provider(BaseProvider):
 
         new_records = []
         for dns_tr in records:
-            tds = dns_tr.findAll("td")
+            tds = dns_tr.find_all("td")
             # Process HTML in the TR children to derive each object
             rec = {}
             rec["zone_id"] = tds[0].string


### PR DESCRIPTION
The `.findAll()` method was deprecated in Beautiful Soup 4.0.

Usage of deprecated methods in `dns-lexicon` results in test failures because `pyproject.toml` instructs `pytest` to treat all warnings as errors.

We can just use `.find_all()` because `dns-lexicon` requires `beautifulsoup4 >= 4` anyway.