### PR TITLE
Implemented function _get_root_domain_name.

### DIFF
--- a/src/lexicon/_private/providers/dynu.py
+++ b/src/lexicon/_private/providers/dynu.py
@@ -33,10 +33,11 @@ class Provider(BaseProvider):
         self.api_endpoint = "https://api.dynu.com/v2"
 
     def authenticate(self):
+        root_domain_name = self._get_root_domain_name()
         data = self._get("/dns")
         domains = data["domains"]
         for domain in domains:
-            if domain["name"].lower() == self.domain.lower():
+            if domain["name"].lower() == root_domain_name:
                 self.domain_id = domain["id"]
                 break
         else:
@@ -183,6 +184,11 @@ class Provider(BaseProvider):
             )
         response.raise_for_status()
         return response.json()
+
+    # Fetch the root domain name
+    def _get_root_domain_name(self):
+        payload = self._get(f"/dns/getroot/{self.domain}")
+        return payload["domainName"]
 
     # Fetch a record by its ID
     def _fetch_record(self, identifier):

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate.yaml
@@ -35,4 +35,40 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/getroot/example.com
+  response:
+    body:
+      string: '{"statusCode":200,"id":1024,"domainName":"example.com","hostname":"example.com","node":""}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:14 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/dynu/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -35,4 +35,40 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://api.dynu.com/v2/dns/getroot/example.com
+  response:
+    body:
+      string: '{"statusCode":200,"id":1024,"domainName":"example.com","hostname":"example.com","node":""}'
+    headers:
+      Cache-Control:
+      - no-store
+      Content-Length:
+      - '90'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 12 Mar 2020 22:19:15 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Dynu Web Server
+      X-Powered-By:
+      - Dynu Dynamic DNS Service
+    status:
+      code: 200
+      message: OK
 version: 1


### PR DESCRIPTION
Currently, the authenticate function only allows creation of certificates for root domain name because the authenticate function compares the hostname with the root domain name. Comparing the root domain name of the hostname with the root domain name can resolve this issue. Implemented the _get_root_domain_name function which is now used in the authenticate function.