### PR TITLE
Allow lexicon providers to define their acceptable record types

### DIFF
--- a/src/lexicon/_private/parser.py
+++ b/src/lexicon/_private/parser.py
@@ -28,7 +28,6 @@ def generate_base_provider_parser() -> argparse.ArgumentParser:
         "type",
         help="specify the entry type",
         default="TXT",
-        choices=["A", "AAAA", "CNAME", "MX", "NS", "SOA", "TXT", "SRV", "LOC"],
     )
 
     parser.add_argument("--name", help="specify the record name")

--- a/src/lexicon/_private/providers/powerdns.py
+++ b/src/lexicon/_private/providers/powerdns.py
@@ -31,7 +31,7 @@ import requests
 from lexicon.interfaces import Provider as BaseProvider
 
 LOGGER = logging.getLogger(__name__)
-
+BaseProvider.VALID_TYPES = []
 
 class PowerDNSProviderError(Exception):
     """Generic PowerDNS exception"""

--- a/src/lexicon/interfaces.py
+++ b/src/lexicon/interfaces.py
@@ -66,6 +66,13 @@ class Provider(ABC):
         self.domain = str(self.config.resolve("lexicon:domain"))
         self.domain_id = None
 
+        # Check the type is valid for the given provider.
+        if not self._type_valid(self.VALID_TYPES):
+            raise ValueError(self._get_lexicon_option('type') + " records are not supported by " + self.provider_name )
+
+    # Default types, override by changing this in the provider, disable check by setting to []
+    VALID_TYPES=["A", "AAAA", "CNAME", "MX", "NS", "SOA", "TXT", "SRV", "LOC"]
+
     # Provider API: instance methods
 
     @abstractmethod
@@ -228,3 +235,12 @@ class Provider(ABC):
 
     def _get_provider_option(self, option: str) -> str | None:
         return self.config.resolve(f"lexicon:{self.provider_name}:{option}")
+
+    def _type_valid(self, types: list[str]=[]) -> bool:
+        if types.len() == 0:
+            return True
+        try:
+            types.index(self._get_lexicon_option("type"))
+        except:
+            return False
+        return True

--- a/src/lexicon/interfaces.py
+++ b/src/lexicon/interfaces.py
@@ -237,7 +237,7 @@ class Provider(ABC):
         return self.config.resolve(f"lexicon:{self.provider_name}:{option}")
 
     def _type_valid(self, types: list[str]=[]) -> bool:
-        if types.len() == 0:
+        if len(types) == 0:
             return True
         try:
             types.index(self._get_lexicon_option("type"))


### PR DESCRIPTION
Do this via overriding the class variable VALID_TYPES,
which is set by default to be the same list as is currently used.
    
See powerdns.py for an example of doing this.
It sets the list to an empty list, which means any RR type is valid.

We set the default list to the same list as is currently used.

----

PowerDNS, supports arbitrary RR types along the lines of RFC 3597, so not restricting the RR types is appropriate.
https://doc.powerdns.com/authoritative/appendices/types.html#unknown-dns-resource-record-rr-types

-----

I would presume the limitations of the RR types here was the LCD of supported RR types across the various registrars.