### PR TITLE
Fix TXT challenge records not being deleted for OVH provider

### DIFF
--- a/src/lexicon/_private/providers/ovh.py
+++ b/src/lexicon/_private/providers/ovh.py
@@ -166,7 +166,7 @@ class Provider(BaseProvider):
             records = [
                 record
                 for record in records
-                if record["content"].lower() == content.lower()
+                if record["content"].lower() in {content.lower(), f"\"{content.lower()}\""}
             ]
 
         LOGGER.debug("list_records: %s", records)

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.fqdn", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.fqdn", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659742,"subDomain":"_acme-challenge.fqdn"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659742,"subDomain":"_acme-challenge.fqdn"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.full", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.full", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659743,"subDomain":"_acme-challenge.full"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659743,"subDomain":"_acme-challenge.full"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.test", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.test", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659745,"subDomain":"_acme-challenge.test"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659745,"subDomain":"_acme-challenge.test"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -104,7 +104,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.createrecordset", "target":
-      "challengetoken1", "ttl": 3600}'
+      "\"challengetoken1\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659750
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -216,7 +216,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.createrecordset", "target":
-      "challengetoken2", "ttl": 3600}'
+      "\"challengetoken2\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -228,7 +228,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659751,"subDomain":"_acme-challenge.createrecordset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659751,"subDomain":"_acme-challenge.createrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testfilt", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "delete.testfilt", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659753,"subDomain":"delete.testfilt"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659753,"subDomain":"delete.testfilt"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659753
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659753,"subDomain":"delete.testfilt"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659753,"subDomain":"delete.testfilt"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testfqdn", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "delete.testfqdn", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659754,"subDomain":"delete.testfqdn"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659754,"subDomain":"delete.testfqdn"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659754
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659754,"subDomain":"delete.testfqdn"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659754,"subDomain":"delete.testfqdn"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testfull", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "delete.testfull", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659759,"subDomain":"delete.testfull"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659759,"subDomain":"delete.testfull"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659759
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659759,"subDomain":"delete.testfull"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659759,"subDomain":"delete.testfull"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testid", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "delete.testid", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659763,"subDomain":"delete.testid"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659763,"subDomain":"delete.testid"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659763
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659763,"subDomain":"delete.testid"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659763,"subDomain":"delete.testid"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -104,7 +104,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordinset",
-      "target": "challengetoken1", "ttl": 3600}'
+      "target": "\"challengetoken1\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659769
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -216,7 +216,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordinset",
-      "target": "challengetoken2", "ttl": 3600}'
+      "target": "\"challengetoken2\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -228,7 +228,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -310,7 +310,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659769
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -337,7 +337,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659771
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -447,7 +447,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659771
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -104,7 +104,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordset", "target":
-      "challengetoken1", "ttl": 3600}'
+      "\"challengetoken1\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659798
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -216,7 +216,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordset", "target":
-      "challengetoken2", "ttl": 3600}'
+      "\"challengetoken2\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -228,7 +228,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659800,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659800,"subDomain":"_acme-challenge.deleterecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -310,7 +310,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659798
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -337,7 +337,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659800
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659800,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659800,"subDomain":"_acme-challenge.deleterecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -104,7 +104,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.listrecordset", "target":
-      "challengetoken1", "ttl": 3600}'
+      "\"challengetoken1\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659826
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -216,7 +216,7 @@ interactions:
     status: {code: 200, message: OK}
 - request:
     body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.listrecordset", "target":
-      "challengetoken2", "ttl": 3600}'
+      "\"challengetoken2\"", "ttl": 3600}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']
@@ -228,7 +228,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -310,7 +310,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659826
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -337,7 +337,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659832
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -329,7 +329,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659838
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659838,"subDomain":"random.fqdntest"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659838,"subDomain":"random.fqdntest"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -356,7 +356,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659860
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659860,"subDomain":"random.fulltest"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659860,"subDomain":"random.fulltest"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -383,7 +383,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659867
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659867,"subDomain":"random.test"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659867,"subDomain":"random.test"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -491,7 +491,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659750
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -518,7 +518,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659751
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659751,"subDomain":"_acme-challenge.createrecordset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659751,"subDomain":"_acme-challenge.createrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -545,7 +545,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659771
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -572,7 +572,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659742
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659742,"subDomain":"_acme-challenge.fqdn"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659742,"subDomain":"_acme-challenge.fqdn"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -599,7 +599,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659743
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659743,"subDomain":"_acme-challenge.full"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659743,"subDomain":"_acme-challenge.full"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -626,7 +626,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659826
   response:
-    body: {string: '{"target":"challengetoken1","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -653,7 +653,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659832
   response:
-    body: {string: '{"target":"challengetoken2","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
+    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -680,7 +680,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659752
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659752,"subDomain":"_acme-challenge.noop"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659752,"subDomain":"_acme-challenge.noop"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -707,7 +707,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659745
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659745,"subDomain":"_acme-challenge.test"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659745,"subDomain":"_acme-challenge.test"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.test", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "orig.test", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659879,"subDomain":"orig.test"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659879,"subDomain":"orig.test"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659879
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659879,"subDomain":"orig.test"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659879,"subDomain":"orig.test"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -215,7 +215,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"subDomain": "updated.test", "target": "challengetoken"}'
+    body: '{"subDomain": "updated.test", "target": "\"challengetoken\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.nameonly.test", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "orig.nameonly.test", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659905,"subDomain":"orig.nameonly.test"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659905,"subDomain":"orig.nameonly.test"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659905
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659905,"subDomain":"orig.nameonly.test"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659905,"subDomain":"orig.nameonly.test"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.testfqdn", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "orig.testfqdn", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659909,"subDomain":"orig.testfqdn"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659909,"subDomain":"orig.testfqdn"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659909
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659909,"subDomain":"orig.testfqdn"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659909,"subDomain":"orig.testfqdn"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -215,7 +215,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"subDomain": "updated.testfqdn", "target": "challengetoken"}'
+    body: '{"subDomain": "updated.testfqdn", "target": "\"challengetoken\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -103,7 +103,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.testfull", "target": "challengetoken",
+    body: '{"fieldType": "TXT", "subDomain": "orig.testfull", "target": "\"challengetoken\"",
       "ttl": 3600}'
     headers:
       Accept: ['*/*']
@@ -116,7 +116,7 @@ interactions:
     method: POST
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659914,"subDomain":"orig.testfull"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659914,"subDomain":"orig.testfull"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -198,7 +198,7 @@ interactions:
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659914
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659914,"subDomain":"orig.testfull"}'}
+    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659914,"subDomain":"orig.testfull"}'}
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -215,7 +215,7 @@ interactions:
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
     status: {code: 200, message: OK}
 - request:
-    body: '{"subDomain": "updated.testfull", "target": "challengetoken"}'
+    body: '{"subDomain": "updated.testfull", "target": "\"challengetoken\""}'
     headers:
       Accept: ['*/*']
       Accept-Encoding: ['gzip, deflate']


### PR DESCRIPTION
OVH API now systematically wraps the content of TXT records in double quotes.
Eg this is a sample request on the live API:

```
POST /1.0/domain/zone/****.ovh/record
Content-Type: application/json

{"fieldType": "A", "subDomain": "test", "target": "test", "ttl": 0}

...

{"fieldType":"TXT","id":5390038375,"subDomain":"test","target":"\"test\"","ttl":0,"zone":"****.ovh"}
```

this is also valid for the output of `GET /record/{id}` requests : 

```
{
  "fieldType": "TXT",
  "id": 5390038375,
  "subDomain": "test",
  "target": "\"test\"",
  "ttl": 0,
  "zone": "****.ovh"
}
```

This affects the lexicon lib. Before deleting the record, the content of the "target" field is compared for exact match and as a result, no records are being deleted : 

```
DEBUG:urllib3.connectionpool:https://eu.api.ovh.com:443 "GET /1.0/domain/zone/****.ovh/record?fieldType=TXT&subDomain=_acme-challenge.test HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:https://eu.api.ovh.com:443 "GET /1.0/domain/zone/****.ovh/record/5390024380 HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:https://eu.api.ovh.com:443 "GET /1.0/domain/zone/****.ovh/record/5390024381 HTTP/1.1" 200 None
DEBUG:lexicon.providers.ovh:list_records: []
DEBUG:lexicon.providers.ovh:delete_records: []
DEBUG:urllib3.connectionpool:https://eu.api.ovh.com:443 "POST /1.0/domain/zone/****.ovh/refresh HTTP/1.1" 200 4
DEBUG:lexicon.providers.ovh:delete_record: True
```

This PR adresses the issue by comparing the expected content to both `content` and `"content"` just in case OVH API is not consistent across time or regions, which wouldn't surprise me anymore.