### PR TITLE
deSEC: Allow preservation of TTL

### DIFF
--- a/src/lexicon/_private/providers/desec.py
+++ b/src/lexicon/_private/providers/desec.py
@@ -250,16 +250,13 @@ class Provider(BaseProvider):
         if data:
             ttl_cur = int(data.get("ttl", 0))
             ttl_opt = int(self._get_lexicon_option("ttl") or 3600)
-            if not ttl_cur or ttl_opt != 3600:
-                # Override by user / set default
-                data["ttl"] = str(ttl_opt)
-            elif action == "PATCH" and ttl_cur < 3600:
+            if ttl_cur == ttl_opt or (action == "PATCH" and ttl_cur < 3600):
                 # Preserve current value if under 3600, this is necessary for dynDNS use cases
                 # The API clamps values under 3600 (if set) but keeps the current if unset
                 del data["ttl"]
             else:
-                # Fallback for allow setting a TTL of 3600
-                data["ttl"] = "3600"
+                # Override by user / set default
+                data["ttl"] = str(ttl_opt)
 
         response = self._session.request(
             action,

--- a/src/lexicon/_private/providers/desec.py
+++ b/src/lexicon/_private/providers/desec.py
@@ -248,18 +248,18 @@ class Provider(BaseProvider):
         # TTL is required for all deSEC record sets
         # It can be omitted in PATCH requests, which keeps the RR's current TTL
         if data:
-            ttl_cur = data.get("ttl", 0)
-            ttl_opt = self._get_lexicon_option("ttl") or 3600
+            ttl_cur = int(data.get("ttl", 0))
+            ttl_opt = int(self._get_lexicon_option("ttl") or 3600)
             if not ttl_cur or ttl_opt != 3600:
                 # Override by user / set default
-                data["ttl"] = ttl_opt
+                data["ttl"] = str(ttl_opt)
             elif action == "PATCH" and ttl_cur < 3600:
                 # Preserve current value if under 3600, this is necessary for dynDNS use cases
                 # The API clamps values under 3600 (if set) but keeps the current if unset
                 del data["ttl"]
             else:
                 # Fallback for allow setting a TTL of 3600
-                data["ttl"] = 3600
+                data["ttl"] = "3600"
 
         response = self._session.request(
             action,


### PR DESCRIPTION
The API clamps values under 3600 (if set) but keeps the current if unset.
This is for a special use case, which does not work without this hack.