### PR TITLE
add http.net as provider

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -49,6 +49,7 @@ lexicon/providers/henet.py          @hank
 lexicon/providers/hetzner.py        @rembik @cgoIT
 lexicon/providers/hostingde.py      @initit
 lexicon/providers/hover.py          @bkanuka
+lexicon/providers/hostingde.py      @saz
 lexicon/providers/infomaniak.py     @l3o-pold
 lexicon/providers/internetbs.py     @edausq
 lexicon/providers/inwx.py           @lociii

--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,7 @@ Lexicon currently supports 89 providers:
 .. _hetzner: https://dns.hetzner.com/api-docs/
 .. _hostingde: https://www.hosting.de/
 .. _hover: https://www.hover.com/
+.. _httpnet: https://www.http.net/
 .. _infoblox: https://docs.infoblox.com/display/ilp/infoblox+documentation+portal
 .. _infomaniak: https://www.infomaniak.com
 .. _internetbs: https://internetbs.net/resellerregistrardomainnameapi

--- a/docs/providers/httpnet.rst
+++ b/docs/providers/httpnet.rst
@@ -1,0 +1,2 @@
+httpnet
+    * ``auth_token`` Specify api key for authentication

--- a/docs/providers_options.rst
+++ b/docs/providers_options.rst
@@ -126,6 +126,9 @@ List of options
 .. _hover:
 .. include:: providers/hover.rst
 
+.. _httpnet:
+.. include:: providers/httpnet.rst
+
 .. _infoblox:
 .. include:: providers/infoblox.rst
 

--- a/src/lexicon/_private/providers/httpnet.py
+++ b/src/lexicon/_private/providers/httpnet.py
@@ -1,0 +1,257 @@
+"""Module provider for httpnet (http.net)"""
+
+import json
+import logging
+import time
+from argparse import ArgumentParser
+from typing import List
+
+import requests
+
+from lexicon.interfaces import Provider as BaseProvider
+
+LOGGER = logging.getLogger(__name__)
+
+# be aware to provide an auth_token
+# LEXICON_HTTPNET_AUTH_TOKEN
+
+
+class Provider(BaseProvider):
+    """Provider class for httpnet"""
+
+    @staticmethod
+    def get_nameservers() -> List[str]:
+        return ["routing.net"]
+
+    @staticmethod
+    def configure_parser(parser: ArgumentParser) -> None:
+        parser.add_argument("--auth-token", help="specify api key for authentication")
+
+    def __init__(self, config):
+        super(Provider, self).__init__(config)
+        self.domain_id = None
+        self.api_endpoint = "https://partner.http.net/api/dns/v1/json"
+
+    def authenticate(self):
+        response = self._get_zone_config()
+
+        LOGGER.debug("authenticate debug: %s", response)
+        if response == []:
+            raise Exception(f"Domain {self.domain} not found")
+
+        self.domain_id = response.get("id", None)
+
+    def cleanup(self) -> None:
+        pass
+
+    # Helper
+    def _get_zone_config(self):
+        data = {"filter": {"field": "ZoneName", "value": self.domain}}
+        response = self._request(action="POST", url="/zoneConfigsFind", data=data)
+        if response != []:
+            return response[0]
+
+        return []
+
+    # Normal Behaviour List all records. If filters are provided, send to the API if possible,
+    # else apply filter locally. Return value should be a list of records.
+    # Return an empty list if no records found
+    # type, name and content are used to filter records.
+    # caused the fact, that provider will enclose TXT values with ""
+    # we have filter content afterwords
+    def list_records(self, rtype=None, name=None, content=None):
+        data = {}
+        subfilter = []  # used by API to filter
+        subfilter.append({"field": "zoneConfigId", "value": self.domain_id})
+        if rtype:
+            subfilter.append({"field": "RecordType", "value": rtype})
+        if name:
+            subfilter.append({"field": "RecordName", "value": self._full_name(name)})
+        if subfilter:
+            data.update(
+                {"filter": {"subFilterConnective": "AND", "subFilter": subfilter}}
+            )
+
+        LOGGER.debug("list_records filter: %s", data)
+        raw_records = self._request(action="POST", url="/recordsFind", data=data)
+
+        processed_records = []
+
+        for record in raw_records:
+            processed_record = {
+                "type": record["type"],
+                "name": self._full_name(record["name"]),
+                "ttl": record["ttl"],
+                "id": record["id"],
+                "content": record["content"],
+            }
+            if record["priority"]:
+                processed_record["priority"] = record["priority"]
+            processed_record = self._clean_TXT_record(processed_record)
+
+            processed_records.append(processed_record)
+
+        if content:
+            processed_records = [
+                record
+                for record in processed_records
+                if record["content"].lower() == content.lower()
+            ]
+
+        LOGGER.debug("list_records: %s", processed_records)
+        return processed_records
+
+    # Normal Behavior Create a new DNS record. Return a boolean True if successful.
+    # If Record Already Exists Do nothing. DO NOT throw exception.
+    # TTL If not specified or set to 0, use reasonable default.
+    def create_record(self, rtype, name, content):
+        records = self.list_records(rtype, name, content)
+        if records:
+            LOGGER.debug("not creating duplicate record: %s", records[0])
+            return True
+
+        zone_config = self._get_zone_config()
+        priority = self._get_lexicon_option("priority")
+        ttl = self._get_lexicon_option("ttl")
+
+        record = {"name": self._full_name(name), "type": rtype, "content": content}
+        if ttl:
+            if int(ttl) < 60:
+                LOGGER.warning("ttl must be minimum 60")
+                ttl = 60
+            record["ttl"] = int(ttl)
+        if priority:
+            record["priority"] = int(priority)
+
+        LOGGER.debug("create_record: %s", record)
+        data = {"zoneConfig": zone_config, "recordsToAdd": [record]}
+
+        self._request(action="POST", url="/zoneUpdate", data=data)
+        return True
+
+    # Normal Behaviour Update a record. Record to be updated can be specified by providing id OR
+    # name, type and content. Return a boolean
+    # True if successful.
+    # TTL:
+    #    If not specified, do not modify ttl.
+    #    If set to 0, reset to reasonable default.
+    # No Match Throw exception?
+    # Update a record. use delete & create cause there is no API update call
+    def update_record(self, identifier, rtype=None, name=None, content=None):
+        if identifier:
+            records = self.list_records()
+            records = [r for r in records if r["id"] == identifier]
+        else:
+            records = self.list_records(rtype, name, None)
+
+        if not records:
+            raise Exception("Record not found")
+        if len(records) > 1:
+            raise Exception("Record not unique")
+        orig_record = records[0]
+        orig_id = orig_record["id"]
+
+        new_rtype = rtype if rtype else orig_record["type"]
+        new_name = name if name else orig_record["name"]
+        new_content = content if content else orig_record["content"]
+
+        self.delete_record(orig_id)
+        return self.create_record(new_rtype, new_name, new_content)
+
+    # Normal Behaviour Remove a record. Record to be deleted can be
+    # specified by providing id OR name, type and content.
+    # Return a boolean True if successful.
+    # No Match Do nothing. DO NOT throw exception
+    def delete_record(self, identifier=None, rtype=None, name=None, content=None):
+        delete_record_ids = []
+        if not identifier:
+            records = self.list_records(rtype, name, content)
+            delete_record_ids = [record["id"] for record in records]
+        else:
+            delete_record_ids.append(identifier)
+
+        LOGGER.debug("delete_records: %s", delete_record_ids)
+        records = []
+        for record_id in delete_record_ids:
+            records.append({"id": record_id})
+
+        zone_config = self._get_zone_config()
+        data = {"zoneConfig": zone_config, "recordsToDelete": records}
+
+        self._request(action="POST", url="/zoneUpdate", data=data)
+
+        # sometimes it takes some time to delete a record
+        # so, here check after deleting and loop
+        # if record(s) is not deleted after 30 seconds > False
+        retries = 30
+        for record_id in delete_record_ids:
+            while True:
+                if self.list_records(record_id):
+                    if retries < 1:
+                        break
+                    retries = retries - 1
+                    time.sleep(1)
+                else:
+                    break
+
+        LOGGER.debug("delete_records: %s", retries > 0)
+        return retries > 0
+
+    def _request(self, action="GET", url="/", data=None, query_params=None):
+        if data is None:
+            data = {}
+        data.update({"authToken": self._get_provider_option("auth_token")})
+
+        read_page = 1
+        return_data = []
+        retries = 30
+
+        # in some situatons, API uses pagination
+        # here we check and if there is pagination, go through all pages
+        while True:
+            page_data = data
+            page_data.update({"page": read_page})
+
+            response = requests.request(
+                action,
+                self.api_endpoint + url,
+                params=query_params,
+                data=json.dumps(page_data),
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            response_json = response.json()  # Work with json Object
+            LOGGER.debug("_request response: %s", response_json)
+            status = response_json.get("status", "*** no status available ***")
+            # if API still busy just wait and retry
+            if (
+                status == "error"
+                and response_json.get("errors")[0].get("value", "") == "blocked"
+            ):
+                if retries < 1:
+                    raise Exception(f"Api error: {response_json.get('errors')}")
+                retries = retries - 1
+                time.sleep(1)
+                continue
+
+            if status not in ("success", "pending"):
+                raise Exception(f"Api error: {response_json.get('errors')}")
+            # check if there a data object
+            read_data = response_json.get("response", {}).get("data", None)
+
+            # if no data object, check if there a records object
+            if read_data is None:
+                read_data = response_json.get("response", {}).get("records", None)
+
+            # add response data to return data
+            if read_data:
+                return_data += read_data
+
+            # is there pagination and more data available?
+            total_pages = response_json.get("response", {}).get("totalPages", 0)
+            if total_pages in (read_page, 0):
+                break  # no more data
+
+            read_page = read_page + 1
+
+        return return_data

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_authenticate.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085449983-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:54:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -1,0 +1,45 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "thisisadomainidonotown.com"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '148'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085450113-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '400'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:54:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -1,0 +1,329 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085450585-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:54:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "A"}, {"field":
+      "RecordName", "value": "localhost.lexicon-example-domain.de"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '304'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085450713-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:54:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085455752-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:54:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:42:38Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "localhost.lexicon-example-domain.de", "type": "A", "content": "127.0.0.1",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '768'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085455904-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031000 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:54:56Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '9054'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:54:56 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -1,0 +1,338 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085456275-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:54:56 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "CNAME"},
+      {"field": "RecordName", "value": "docs.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '303'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085456420-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085500196-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:54:56Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "docs.lexicon-example-domain.de", "type": "CNAME", "content": "docs.example.com",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '774'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085500325-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031001 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           }\n        ],\n        \"zoneConfig\": {\n            \"accountId\":
+        \"181217txillqrawg3w2\",\n            \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \           \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\": null,\n
+        \           \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:55:00Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '9618'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -1,0 +1,360 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085510611-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:10 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.fqdn.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085510742-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:13 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085514015-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:10Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.fqdn.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '786'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085514139-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031004 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:55:14Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '11358'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -1,0 +1,353 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085506735-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:06Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:06 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.full.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085506860-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:10 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085510186-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:06Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:10 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:06Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.full.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '786'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085510312-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031003 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:06Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:55:10Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '10778'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:10 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -1,0 +1,396 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085500642-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.test.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085500774-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085505099-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:00Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.test.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '787'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085505224-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:00Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.test.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '787'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085506442-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031002 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '10198'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:06 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -1,0 +1,929 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085729997-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:30 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.createrecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '328'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085730113-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:33 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085733655-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:33 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:29Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.createrecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken1", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '798'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085733805-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031030 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:57:33Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '17115'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.createrecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '328'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085734116-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '987'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085734241-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:33Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.createrecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085734381-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:33Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.createrecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085735683-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:35 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:33Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.createrecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085736939-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031031 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:34Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:57:37Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '17707'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:37 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -1,0 +1,540 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085725505-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:18Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:25 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.noop.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085725638-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:28 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085729244-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:18Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:29 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:18Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.noop.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '786'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085729368-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031029 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:18Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:57:29Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '16523'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:29 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.noop.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085729764-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:29Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310nv53yqa5tykse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"name\": \"_acme-challenge.noop.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '975'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:29 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.noop.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '317'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085729879-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:29Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310nv53yqa5tykse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"name\": \"_acme-challenge.noop.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '975'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:29 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -1,0 +1,985 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085642987-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:35Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:43 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfilt.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085643125-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:46 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085646760-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:35Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:46 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:35Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "delete.testfilt.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '781'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085646881-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031023 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:35Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:47Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310zlq4fwwowgrro\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:47Z\",\n                \"name\":
+        \"delete.testfilt.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:56:47Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '16518'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:47 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfilt.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085647150-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:47Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310zlq4fwwowgrro\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:47Z\",\n                \"name\": \"delete.testfilt.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '970'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:47 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085647285-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:47Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:47 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:47Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310zlq4fwwowgrro"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085647401-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:47 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:47Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310zlq4fwwowgrro"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085648668-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:48 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:47Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310zlq4fwwowgrro"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085649869-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031024 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:47Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:56:49Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15943'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310zlq4fwwowgrro"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085650142-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:53 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfilt.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085653724-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:56 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -1,0 +1,985 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085711290-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:04Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:11 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfqdn.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085711429-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085714919-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:04Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:04Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "delete.testfqdn.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '781'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085715048-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031027 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:04Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:15Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310v5ojcnl643i4o\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:15Z\",\n                \"name\":
+        \"delete.testfqdn.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:57:15Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '16518'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfqdn.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085715430-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:15Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310v5ojcnl643i4o\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:15Z\",\n                \"name\": \"delete.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '970'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085715560-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:15Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:15Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310v5ojcnl643i4o"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085715694-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:15Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310v5ojcnl643i4o"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085716908-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:17 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:15Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310v5ojcnl643i4o"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085718110-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031028 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:15Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:57:18Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15943'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310v5ojcnl643i4o"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085718397-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:21 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfqdn.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085721997-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:25 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -1,0 +1,985 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085657120-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:49Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:57 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfull.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085657259-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085700757-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:49Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:49Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "delete.testfull.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '781'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085700893-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031025 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:50Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:01Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603104aetbks2mssz4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:01Z\",\n                \"name\":
+        \"delete.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:57:01Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '16518'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:01 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfull.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085701190-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:01Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"2603104aetbks2mssz4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:01Z\",\n                \"name\": \"delete.testfull.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '970'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:01 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085701303-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:01Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:01 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:01Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "2603104aetbks2mssz4"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085701435-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:01 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:01Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "2603104aetbks2mssz4"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085702707-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:02 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:01Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "2603104aetbks2mssz4"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085704034-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031026 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:01Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:57:04Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15943'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:04 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "2603104aetbks2mssz4"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085704367-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:07 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testfull.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085707914-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:11 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -1,0 +1,985 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085629162-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:29 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testid.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085629293-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:32 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085632509-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:32 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:28Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "delete.testid.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '779'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085632664-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031021 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:29Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:32Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w2je5dj4pnxwy\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:32Z\",\n                \"name\":
+        \"delete.testid.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:56:32Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '16516'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:32 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testid.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085632950-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:32Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310w2je5dj4pnxwy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:32Z\",\n                \"name\": \"delete.testid.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '968'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:32 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085633075-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:32Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:33 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:32Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310w2je5dj4pnxwy"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085633209-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:33 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:32Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310w2je5dj4pnxwy"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085634439-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:32Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310w2je5dj4pnxwy"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085635651-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031022 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:33Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:56:35Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15943'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:35 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310w2je5dj4pnxwy"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085636197-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:39 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "delete.testid.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085639588-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:42 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -1,0 +1,1610 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085812266-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:01Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:12 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordinset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '330'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085812398-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085815757-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:01Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:58:01Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordinset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken1", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '800'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085815908-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031037 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:01Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:58:16Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310fw2zdljrjy2ms\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:16Z\",\n                \"name\": \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:58:16Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '19481'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:16 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordinset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '330'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085816256-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:58:16Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310fw2zdljrjy2ms\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:16Z\",\n                \"name\": \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '989'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:16 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085816396-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:16Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:16 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:58:16Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordinset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085816540-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:16 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:58:16Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordinset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085817764-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:17 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:58:16Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordinset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '801'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085819095-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031038 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:16Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:58:16Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310fw2zdljrjy2ms\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:16Z\",\n                \"name\": \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:58:19Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310hmuh7eo7adrti\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:58:19Z\",\n                \"name\":
+        \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:58:19Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '20075'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:19 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordinset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '330'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085819414-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:58:16Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310fw2zdljrjy2ms\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:16Z\",\n                \"name\": \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:58:19Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310hmuh7eo7adrti\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:58:19Z\",\n                \"name\":
+        \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"limit\": 25,\n
+        \       \"page\": 1,\n        \"totalEntries\": 2,\n        \"totalPages\":
+        1,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1583'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:19 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085819571-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:19Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:19 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:58:19Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310fw2zdljrjy2ms"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085819710-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:19 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:58:19Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310fw2zdljrjy2ms"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085821045-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:21 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:58:19Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310fw2zdljrjy2ms"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085822292-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031039 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:19Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:58:19Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken2\\\"\",\n
+        \               \"id\": \"260310hmuh7eo7adrti\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:19Z\",\n                \"name\": \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:58:22Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '19481'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:22 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310fw2zdljrjy2ms"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085822604-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:26 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordinset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '330'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085826122-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:58:19Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken2\\\"\",\n
+        \               \"id\": \"260310hmuh7eo7adrti\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:58:19Z\",\n                \"name\": \"_acme-challenge.deleterecordinset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '989'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:26 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -1,0 +1,1636 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085751041-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:51 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '328'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085751174-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:54 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085754841-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:54 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:50Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken1", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '798'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085754964-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031034 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:55Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310czjguqawlhkjq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:55Z\",\n                \"name\": \"_acme-challenge.deleterecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:57:55Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '19479'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '328'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085755353-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:55Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310czjguqawlhkjq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:55Z\",\n                \"name\": \"_acme-challenge.deleterecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '987'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085755478-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:55Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:55Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085755614-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:55 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:55Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085756838-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:56 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:55Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.deleterecordset.lexicon-example-domain.de", "type": "TXT",
+      "content": "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085758108-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031035 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:55Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:55Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310czjguqawlhkjq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:55Z\",\n                \"name\": \"_acme-challenge.deleterecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:58Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310jlqncnznhbxze\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:58Z\",\n                \"name\":
+        \"_acme-challenge.deleterecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:57:58Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '20071'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:58 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '328'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085758431-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:55Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310czjguqawlhkjq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:55Z\",\n                \"name\": \"_acme-challenge.deleterecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:58Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310jlqncnznhbxze\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:58Z\",\n                \"name\":
+        \"_acme-challenge.deleterecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"limit\": 25,\n
+        \       \"page\": 1,\n        \"totalEntries\": 2,\n        \"totalPages\":
+        1,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1579'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:58 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085758576-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:58Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:58 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:58Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310czjguqawlhkjq"}, {"id": "260310jlqncnznhbxze"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '735'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085758707-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:58 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:58Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310czjguqawlhkjq"}, {"id": "260310jlqncnznhbxze"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '735'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085759945-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:58Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310czjguqawlhkjq"}, {"id": "260310jlqncnznhbxze"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '735'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085801271-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031036 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:58Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:58:01Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '18887'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:01 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310czjguqawlhkjq"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085801607-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:04 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310jlqncnznhbxze"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085805075-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:08 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.deleterecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '328'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085808606-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:58:12 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
@@ -1,0 +1,444 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085527106-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:27 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "ttl.fqdn.lexicon-example-domain.de"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '305'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085527238-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:30 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085530635-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:30 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:26Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "ttl.fqdn.lexicon-example-domain.de", "type": "TXT", "content": "ttlshouldbe3600",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '775'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085530764-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031008 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:27Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:55:30Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '13648'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:30 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "ttl.fqdn.lexicon-example-domain.de"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '305'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085531020-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '964'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:31 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -1,0 +1,1125 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085741127-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:41 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.listrecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '326'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085741253-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:44 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085744848-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:44 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:37Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.listrecordset.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken1", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '796'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085744993-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031032 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:57:45Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '18297'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:45 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.listrecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '326'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085745333-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '985'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:45 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085745474-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:45 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:45Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.listrecordset.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '797'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085745628-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:45 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:45Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.listrecordset.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '797'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085746860-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:46 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:45Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.listrecordset.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '797'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085748111-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:48 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:45Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.listrecordset.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '797'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085749357-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:49 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:57:45Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "_acme-challenge.listrecordset.lexicon-example-domain.de", "type": "TXT", "content":
+      "challengetoken2", "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '797'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085750584-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031033 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:29Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nv53yqa5tykse\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:29Z\",\n                \"name\":
+        \"_acme-challenge.noop.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:33Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"26031064622btn3uwsy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:33Z\",\n                \"name\": \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"260310lnfgyfz2so2as\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:37Z\",\n                \"name\":
+        \"_acme-challenge.createrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:57:50Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '18887'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "_acme-challenge.listrecordset.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '326'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085750897-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:57:45Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken1\\\"\",\n
+        \               \"id\": \"260310ohpqatpbmhim4\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:45Z\",\n                \"name\": \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:57:50Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken2\\\"\",\n                \"id\": \"2603106cfhjb32rnkgo\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:57:50Z\",\n                \"name\":
+        \"_acme-challenge.listrecordset.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"limit\": 25,\n
+        \       \"page\": 1,\n        \"totalEntries\": 2,\n        \"totalPages\":
+        1,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1575'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -1,0 +1,439 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085522719-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:22 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "random.fqdntest.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085522855-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:26 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085526532-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:26 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:22Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "random.fqdntest.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '781'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085526652-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031007 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:55:26Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '13079'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:26 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "random.fqdntest.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085526978-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:26Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310w4ofrsc56uuke\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"name\": \"random.fqdntest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '970'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:27 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -1,0 +1,431 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085518711-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "random.fulltest.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085518839-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:21 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085522066-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:22 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:18Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "random.fulltest.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '781'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085522209-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031006 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:55:22Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '12504'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:22 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "random.fulltest.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '312'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085522580-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '970'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:22 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -1,0 +1,107 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085737283-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:57:37Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:37 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "filter.thisdoesnotexist.lexicon-example-domain.de"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '320'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085737458-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:57:41 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -1,0 +1,422 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085514755-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "random.test.lexicon-example-domain.de"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '308'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085514891-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085518163-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:14Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "random.test.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '777'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085518284-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031005 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '11929'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "random.test.lexicon-example-domain.de"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '308'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085518581-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:18Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310b6w2tgdbbygic\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"name\": \"random.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '966'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -1,0 +1,238 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085514499-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085514623-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310ghudtxqxl65is\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:06Z\",\n                \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:42:38Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"116.202.71.49\",\n                \"id\":
+        \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"name\": \"kundenbereich.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"A\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"116.202.71.49\",\n
+        \               \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"aspmx.l.google.com\",\n                \"id\": \"260310d4f3kjett463e\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 1,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt1.aspmx.l.google.com\",\n                \"id\": \"260310zqr447bhbbflq\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net\",\n                \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031005 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        18,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '10592'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -1,0 +1,1428 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085531154-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:31 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.test.lexicon-example-domain.de"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085531282-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085534717-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:34 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:30Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "orig.test.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '775'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085534861-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031009 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:31Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:34Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310d3ldy2puhqji6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:34Z\",\n                \"name\":
+        \"orig.test.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"TXT\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           }\n        ],\n        \"zoneConfig\": {\n            \"accountId\":
+        \"181217txillqrawg3w2\",\n            \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \           \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\": null,\n
+        \           \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:55:34Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14217'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:35 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.test.lexicon-example-domain.de"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '306'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085535173-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:34Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310d3ldy2puhqji6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:34Z\",\n                \"name\": \"orig.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '964'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:35 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085535320-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310ghudtxqxl65is\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:06Z\",\n                \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:42:38Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"116.202.71.49\",\n                \"id\":
+        \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"name\": \"kundenbereich.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"A\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"116.202.71.49\",\n
+        \               \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"aspmx.l.google.com\",\n                \"id\": \"260310d4f3kjett463e\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 1,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt1.aspmx.l.google.com\",\n                \"id\": \"260310zqr447bhbbflq\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net\",\n                \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031010 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:35Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:34Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310d3ldy2puhqji6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:34Z\",\n                \"name\":
+        \"orig.test.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"TXT\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:26Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310w4ofrsc56uuke\",\n                \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n
+        \               \"name\": \"random.fqdntest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310lf2pyqdciie7c\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:22Z\",\n                \"name\":
+        \"random.fulltest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:18Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310b6w2tgdbbygic\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"name\": \"random.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"ttlshouldbe3600\\\"\",\n                \"id\": \"260310ehfwz3wivi7vi\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:30Z\",\n                \"name\":
+        \"ttl.fqdn.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"TXT\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:42:38Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"116.202.71.47\",\n                \"id\":
+        \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"name\": \"www.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"A\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"limit\": 25,\n
+        \       \"page\": 1,\n        \"totalEntries\": 23,\n        \"totalPages\":
+        1,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '13451'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:35 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085535477-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:34Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:35 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:34Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310d3ldy2puhqji6"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085535623-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:35 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:34Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310d3ldy2puhqji6"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085536898-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:37 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:34Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310d3ldy2puhqji6"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085538132-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031010 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:35Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:55:38Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '13648'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:38 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310d3ldy2puhqji6"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085538437-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:42 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "updated.test.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '309'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085542139-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:45 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085545691-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:38Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:45 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:38Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "updated.test.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '778'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085545838-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031011 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:55:45Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:46 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -1,0 +1,1238 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085546256-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:46 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.nameonly.test.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085546374-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:49 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085549920-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:49 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:45Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "orig.nameonly.test.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085550072-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031012 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:46Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:50Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310oz65lcsl7ah24\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:50Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:55:50Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14798'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.nameonly.test.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085550369-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:50Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310oz65lcsl7ah24\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:50Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '973'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085550521-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:50Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:50Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310oz65lcsl7ah24"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085550666-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:50 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:50Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310oz65lcsl7ah24"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085551911-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:52 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:50Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310oz65lcsl7ah24"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085553181-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031013 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:50Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:55:53Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14220'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:53 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310oz65lcsl7ah24"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085553610-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:55:57 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.nameonly.test.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '315'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085557119-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085600675-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:53Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:00 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:55:53Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "orig.nameonly.test.lexicon-example-domain.de", "type": "TXT", "content": "updated",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '777'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085600824-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031014 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:53Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:56:00Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14791'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:01 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -1,0 +1,1566 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085614973-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:15 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.testfqdn.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085615103-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085618594-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:14Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "orig.testfqdn.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '780'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085618734-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:18 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:14Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "orig.testfqdn.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '780'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085619962-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031018 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:15Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:20Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"2603106w47nzpqe74ca\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:20Z\",\n                \"name\": \"orig.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:56:20Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15940'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:20 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.testfqdn.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085620339-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:20Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"2603106w47nzpqe74ca\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:20Z\",\n                \"name\": \"orig.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '968'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:20 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085620483-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310ghudtxqxl65is\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:06Z\",\n                \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:42:38Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"116.202.71.49\",\n                \"id\":
+        \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"name\": \"kundenbereich.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"A\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"116.202.71.49\",\n
+        \               \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"aspmx.l.google.com\",\n                \"id\": \"260310d4f3kjett463e\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 1,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt1.aspmx.l.google.com\",\n                \"id\": \"260310zqr447bhbbflq\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net\",\n                \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031019 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:20Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"updated\\\"\",\n                \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:20Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603106w47nzpqe74ca\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:20Z\",\n                \"name\":
+        \"orig.testfqdn.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:26Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310w4ofrsc56uuke\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"name\": \"random.fqdntest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310lf2pyqdciie7c\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:22Z\",\n                \"name\":
+        \"random.fulltest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:18Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310b6w2tgdbbygic\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"name\": \"random.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"ttlshouldbe3600\\\"\",\n                \"id\": \"260310ehfwz3wivi7vi\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:30Z\",\n                \"name\":
+        \"ttl.fqdn.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"TXT\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:45Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"2603107n5pllotdqkbc\",\n                \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n
+        \               \"name\": \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310f4gsob7y5ftpe\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"name\": \"updated.testfull.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        26,\n        \"totalPages\": 2,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14618'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:20 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}]}, "page": 2}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085620626-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"116.202.71.47\",\n
+        \               \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 2,\n        \"totalEntries\":
+        26,\n        \"totalPages\": 2,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '952'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:20 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085620752-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:20Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:20 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:20Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "2603106w47nzpqe74ca"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085620887-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:21 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:20Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "2603106w47nzpqe74ca"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085622165-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031019 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:20Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:56:22Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15367'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:22 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "2603106w47nzpqe74ca"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085622484-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:25 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "updated.testfqdn.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '313'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085625762-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:28 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085628716-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:22Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:28 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:22Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "updated.testfqdn.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '782'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085628838-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031020 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:22Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:28Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wx6fnvjonidpw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:28Z\",\n                \"name\": \"updated.testfqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:56:28Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15943'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:28 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/httpnet/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -1,0 +1,1439 @@
+interactions:
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085601207-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:01 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.testfull.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085601347-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:04 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085604953-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:04 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:00Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "orig.testfull.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '779'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085605088-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031015 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:01Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:05Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nrj5tyxmjt6uy\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:05Z\",\n                \"name\":
+        \"orig.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:56:05Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15364'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "orig.testfull.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '310'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085605382-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:05Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310nrj5tyxmjt6uy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:05Z\",\n                \"name\": \"orig.testfull.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        1,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '968'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}]}, "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085605508-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310ghudtxqxl65is\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:06Z\",\n                \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:42:38Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"116.202.71.49\",\n                \"id\":
+        \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"name\": \"kundenbereich.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"A\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"116.202.71.49\",\n
+        \               \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"aspmx.l.google.com\",\n                \"id\": \"260310d4f3kjett463e\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 1,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt1.aspmx.l.google.com\",\n                \"id\": \"260310zqr447bhbbflq\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net\",\n                \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031016 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:05Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"updated\\\"\",\n                \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:05Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310nrj5tyxmjt6uy\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:05Z\",\n                \"name\":
+        \"orig.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:26Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310w4ofrsc56uuke\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"name\": \"random.fqdntest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310lf2pyqdciie7c\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:22Z\",\n                \"name\":
+        \"random.fulltest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:18Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310b6w2tgdbbygic\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"name\": \"random.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"ttlshouldbe3600\\\"\",\n                \"id\": \"260310ehfwz3wivi7vi\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:30Z\",\n                \"name\":
+        \"ttl.fqdn.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"TXT\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:45Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"2603107n5pllotdqkbc\",\n                \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n
+        \               \"name\": \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"116.202.71.47\",\n
+        \               \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"limit\": 25,\n        \"page\": 1,\n        \"totalEntries\":
+        25,\n        \"totalPages\": 1,\n        \"type\": \"FindRecordsResult\"\n
+        \   },\n    \"status\": \"success\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14598'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085605638-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:05Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"blocked\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1378'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:05Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310nrj5tyxmjt6uy"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n        {\n            \"code\": 10205,\n            \"contextObject\":
+        \"\",\n            \"contextPath\": \"\",\n            \"details\": [\n            ],\n
+        \           \"text\": \"The current status of an object you are trying to
+        use does not allow that operation.\",\n            \"value\": \"blocked\"\n
+        \       }\n    ],\n    \"metadata\": {\n        \"clientTransactionId\": \"\",\n
+        \       \"serverTransactionId\": \"20260310085605772-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"status\": \"error\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '502'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:05 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:05Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "blocked", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToDelete": [{"id":
+      "260310nrj5tyxmjt6uy"}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '704'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085607096-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031016 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:05Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            }\n
+        \       ],\n        \"zoneConfig\": {\n            \"accountId\": \"181217txillqrawg3w2\",\n
+        \           \"addDate\": \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\":
+        \"off\",\n            \"dnsServerGroupId\": null,\n            \"emailAddress\":
+        \"hostmaster@lexicon-example-domain.de\",\n            \"id\": \"260310i7fx2xtjv6kse\",\n
+        \           \"lastChangeDate\": \"2026-03-10T08:56:07Z\",\n            \"masterIp\":
+        \"\",\n            \"name\": \"lexicon-example-domain.de\",\n            \"nameUnicode\":
+        \"lexicon-example-domain.de\",\n            \"restorableUntil\": null,\n            \"soaValues\":
+        {\n                \"expire\": 3600000,\n                \"negativeTtl\":
+        900,\n                \"refresh\": 86400,\n                \"retry\": 7200,\n
+        \               \"ttl\": 86400\n            },\n            \"status\": \"blocked\",\n
+        \           \"templateValues\": null,\n            \"type\": \"NATIVE\",\n
+        \           \"zoneTransferWhitelist\": [\n            ]\n        }\n    },\n
+        \   \"status\": \"pending\",\n    \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '14791'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:07 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "260310nrj5tyxmjt6uy"}]},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '249'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085607537-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:11 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"subFilterConnective": "AND", "subFilter": [{"field": "zoneConfigId",
+      "value": "260310i7fx2xtjv6kse"}, {"field": "RecordType", "value": "TXT"}, {"field":
+      "RecordName", "value": "updated.testfull.lexicon-example-domain.de"}]}, "page":
+      1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '313'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/recordsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085611120-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n        ],\n        \"limit\":
+        25,\n        \"page\": 1,\n        \"totalEntries\": 0,\n        \"totalPages\":
+        0,\n        \"type\": \"FindRecordsResult\"\n    },\n    \"status\": \"success\",\n
+        \   \"warnings\": [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '396'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"filter": {"field": "ZoneName", "value": "lexicon-example-domain.de"},
+      "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneConfigsFind
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085614541-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"data\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"dnsSecMode\": \"off\",\n                \"dnsServerGroupId\":
+        null,\n                \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \               \"id\": \"260310i7fx2xtjv6kse\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:07Z\",\n                \"masterIp\": \"\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \               \"restorableUntil\": null,\n                \"soaValues\":
+        {\n                    \"expire\": 3600000,\n                    \"negativeTtl\":
+        900,\n                    \"refresh\": 86400,\n                    \"retry\":
+        7200,\n                    \"ttl\": 86400\n                },\n                \"status\":
+        \"active\",\n                \"templateValues\": null,\n                \"type\":
+        \"NATIVE\",\n                \"zoneTransferWhitelist\": [\n                ]\n
+        \           }\n        ],\n        \"limit\": 25,\n        \"page\": 1,\n
+        \       \"totalEntries\": 1,\n        \"totalPages\": 1,\n        \"type\":
+        \"FindZoneConfigsResult\"\n    },\n    \"status\": \"success\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '1377'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zoneConfig": {"accountId": "181217txillqrawg3w2", "addDate": "2026-03-10T08:42:38Z",
+      "dnsSecMode": "off", "dnsServerGroupId": null, "emailAddress": "hostmaster@lexicon-example-domain.de",
+      "id": "260310i7fx2xtjv6kse", "lastChangeDate": "2026-03-10T08:56:07Z", "masterIp":
+      "", "name": "lexicon-example-domain.de", "nameUnicode": "lexicon-example-domain.de",
+      "restorableUntil": null, "soaValues": {"expire": 3600000, "negativeTtl": 900,
+      "refresh": 86400, "retry": 7200, "ttl": 86400}, "status": "active", "templateValues":
+      null, "type": "NATIVE", "zoneTransferWhitelist": []}, "recordsToAdd": [{"name":
+      "updated.testfull.lexicon-example-domain.de", "type": "TXT", "content": "challengetoken",
+      "ttl": 3600}], "page": 1}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '782'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.5
+    method: POST
+    uri: https://partner.http.net/api/dns/v1/json/zoneUpdate
+  response:
+    body:
+      string: "{\n    \"errors\": [\n    ],\n    \"metadata\": {\n        \"clientTransactionId\":
+        \"\",\n        \"serverTransactionId\": \"20260310085614670-dnsrobot-robots1-3007277-0\"\n
+        \   },\n    \"response\": {\n        \"records\": [\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"aspmx.l.google.com\",\n
+        \               \"id\": \"260310d4f3kjett463e\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 1,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"alt1.aspmx.l.google.com\",\n
+        \               \"id\": \"260310zqr447bhbbflq\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": 5,\n                \"recordTemplateId\": null,\n
+        \               \"ttl\": 3600,\n                \"type\": \"MX\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:42:38Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"ns1.routing.net\",\n
+        \               \"id\": \"260310y6yrc6lfizst6\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt2.aspmx.l.google.com\",\n                \"id\": \"26031052ho23dhn7tqg\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 5,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310fmhjrnofkuh52\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"www.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt3.aspmx.l.google.com\",\n                \"id\": \"2603102wpc43wwli3ly\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"alt4.aspmx.l.google.com\",\n                \"id\": \"260310vdjezh7aidgr6\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:42:38Z\",\n                \"name\":
+        \"lexicon-example-domain.de\",\n                \"priority\": 10,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"MX\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.47\",\n                \"id\": \"260310vwzewyujm7bkw\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns3.routing.net\",\n                \"id\": \"260310gey6cl5xahv5s\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns2.routing.net\",\n                \"id\": \"260310gguslo4ftfrju\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"NS\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"260310woym7rikjqh6u\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundencenter.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"ns1.routing.net. hostmaster.lexicon-example-domain.de. 2026031017 86400
+        7200 3600000 900\",\n                \"id\": \"260310mnwsbe5z4pxak\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:07Z\",\n                \"name\": \"lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 86400,\n                \"type\": \"SOA\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"116.202.71.49\",\n                \"id\": \"2603102gyj57qrmqzxy\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:42:38Z\",\n                \"name\": \"kundenbereich.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"127.0.0.1\",\n                \"id\": \"2603102hs7qio3yr376\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:54:56Z\",\n                \"name\": \"localhost.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"A\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:00Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"docs.example.com\",\n                \"id\": \"2603103oypva3uudxc4\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:00Z\",\n                \"name\":
+        \"docs.lexicon-example-domain.de\",\n                \"priority\": null,\n
+        \               \"recordTemplateId\": null,\n                \"ttl\": 3600,\n
+        \               \"type\": \"CNAME\",\n                \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n
+        \           },\n            {\n                \"accountId\": \"181217txillqrawg3w2\",\n
+        \               \"addDate\": \"2026-03-10T08:55:06Z\",\n                \"comments\":
+        \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n                \"id\":
+        \"260310ghudtxqxl65is\",\n                \"lastChangeDate\": \"2026-03-10T08:55:06Z\",\n
+        \               \"name\": \"_acme-challenge.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:10Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310rtaodfxft6waa\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:10Z\",\n                \"name\":
+        \"_acme-challenge.full.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:14Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310wnahwse42lh4i\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:14Z\",\n                \"name\": \"_acme-challenge.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:18Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310b6w2tgdbbygic\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:18Z\",\n                \"name\":
+        \"random.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:22Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"challengetoken\\\"\",\n
+        \               \"id\": \"260310lf2pyqdciie7c\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:22Z\",\n                \"name\": \"random.fulltest.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:26Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310w4ofrsc56uuke\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:26Z\",\n                \"name\":
+        \"random.fqdntest.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:55:30Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"ttlshouldbe3600\\\"\",\n
+        \               \"id\": \"260310ehfwz3wivi7vi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:55:30Z\",\n                \"name\": \"ttl.fqdn.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:55:45Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"2603107n5pllotdqkbc\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:55:45Z\",\n                \"name\":
+        \"updated.test.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            },\n            {\n                \"accountId\":
+        \"181217txillqrawg3w2\",\n                \"addDate\": \"2026-03-10T08:56:00Z\",\n
+        \               \"comments\": \"\",\n                \"content\": \"\\\"updated\\\"\",\n
+        \               \"id\": \"2603105b2cqnlezcdpi\",\n                \"lastChangeDate\":
+        \"2026-03-10T08:56:00Z\",\n                \"name\": \"orig.nameonly.test.lexicon-example-domain.de\",\n
+        \               \"priority\": null,\n                \"recordTemplateId\":
+        null,\n                \"ttl\": 3600,\n                \"type\": \"TXT\",\n
+        \               \"zoneConfigId\": \"260310i7fx2xtjv6kse\"\n            },\n
+        \           {\n                \"accountId\": \"181217txillqrawg3w2\",\n                \"addDate\":
+        \"2026-03-10T08:56:14Z\",\n                \"comments\": \"\",\n                \"content\":
+        \"\\\"challengetoken\\\"\",\n                \"id\": \"260310f4gsob7y5ftpe\",\n
+        \               \"lastChangeDate\": \"2026-03-10T08:56:14Z\",\n                \"name\":
+        \"updated.testfull.lexicon-example-domain.de\",\n                \"priority\":
+        null,\n                \"recordTemplateId\": null,\n                \"ttl\":
+        3600,\n                \"type\": \"TXT\",\n                \"zoneConfigId\":
+        \"260310i7fx2xtjv6kse\"\n            }\n        ],\n        \"zoneConfig\":
+        {\n            \"accountId\": \"181217txillqrawg3w2\",\n            \"addDate\":
+        \"2026-03-10T08:42:38Z\",\n            \"dnsSecMode\": \"off\",\n            \"dnsServerGroupId\":
+        null,\n            \"emailAddress\": \"hostmaster@lexicon-example-domain.de\",\n
+        \           \"id\": \"260310i7fx2xtjv6kse\",\n            \"lastChangeDate\":
+        \"2026-03-10T08:56:14Z\",\n            \"masterIp\": \"\",\n            \"name\":
+        \"lexicon-example-domain.de\",\n            \"nameUnicode\": \"lexicon-example-domain.de\",\n
+        \           \"restorableUntil\": null,\n            \"soaValues\": {\n                \"expire\":
+        3600000,\n                \"negativeTtl\": 900,\n                \"refresh\":
+        86400,\n                \"retry\": 7200,\n                \"ttl\": 86400\n
+        \           },\n            \"status\": \"blocked\",\n            \"templateValues\":
+        null,\n            \"type\": \"NATIVE\",\n            \"zoneTransferWhitelist\":
+        [\n            ]\n        }\n    },\n    \"status\": \"pending\",\n    \"warnings\":
+        [\n    ]\n}\n"
+    headers:
+      content-length:
+      - '15367'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 10 Mar 2026 08:56:14 GMT
+      server:
+      - nginx
+      strict-transport-security:
+      - max-age=15768000
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      - nosniff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/providers/test_httpnet.py
+++ b/tests/providers/test_httpnet.py
@@ -1,0 +1,22 @@
+"""Integration tests for http.net provider"""
+
+from integration_tests import IntegrationTestsV2
+
+
+# Hook into testing framework by inheriting unittest.TestCase and reuse
+# the tests which *each and every* implementation of the interface must
+# pass, by inheritance from integration_tests.IntegrationTests
+class TestHttpnetProvider(IntegrationTestsV2):
+    """Integration tests for httpnet provider"""
+
+    provider_name = "httpnet"
+    domain = "lexicon-example-domain.de"
+
+    def _filter_post_data_parameters(self):
+        return ["authToken"]
+
+    def _filter_headers(self):
+        return ["Authorization"]
+
+    def _filter_query_parameters(self):
+        return ["secret_key"]


### PR DESCRIPTION
This PR adds http.net as provider. It's based on the existing hosting.de provider. They're somehow related, therefore it's the same API, but the infrastructure is different.