### PR TITLE
OVH scoped permissions + TXT field bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master - CURRENT
 ### Modified
 * The `ovh` provider now only requires a token scoped to the managed zone (`/domain/zone/example.com/*`) instead of the whole `/domain/zone/*` scope
+* The `ovh` provider now strips the surrounding double quotes the OVH API adds around TXT record targets. This fixes duplicate detection on `create_record` and makes the `content` returned by `list_records` consistent with the other providers (behavior change: TXT content is no longer quoted)
 
 ## 3.25.2 - 10/05/2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## master - CURRENT
+### Modified
+* The `ovh` provider now only requires a token scoped to the managed zone (`/domain/zone/example.com/*`) instead of the whole `/domain/zone/*` scope
 
 ## 3.25.2 - 10/05/2026
 ### Added

--- a/docs/providers/ovh.rst
+++ b/docs/providers/ovh.rst
@@ -10,7 +10,8 @@ ovh
 
 .. note::
    
-   OVH Provider requires a token with full rights on /domain/*.
-   It can be generated for your OVH account on the following URL:
-   https://api.ovh.com/createToken/index.cgi?GET=/domain/*&PUT=/domain/*&POST=/domain/*&DELETE=/domain/*
+   OVH Provider requires a token with rights on the zone to manage,
+   scoped to /domain/zone/example.com/* (replace example.com with your
+   domain). It can be generated for your OVH account on the following URL:
+   https://api.ovh.com/createToken/index.cgi?GET=/domain/zone/example.com/*&PUT=/domain/zone/example.com/*&POST=/domain/zone/example.com/*&DELETE=/domain/zone/example.com/*
 

--- a/src/lexicon/_private/providers/ovh.py
+++ b/src/lexicon/_private/providers/ovh.py
@@ -40,9 +40,10 @@ class Provider(BaseProvider):
     @staticmethod
     def configure_parser(parser: ArgumentParser) -> None:
         parser.description = """
-            OVH Provider requires a token with full rights on /domain/*.
-            It can be generated for your OVH account on the following URL:
-            https://api.ovh.com/createToken/index.cgi?GET=/domain/*&PUT=/domain/*&POST=/domain/*&DELETE=/domain/*"""
+            OVH Provider requires a token with rights on the zone to manage,
+            scoped to /domain/zone/example.com/* (replace example.com with your
+            domain). It can be generated for your OVH account on the following URL:
+            https://api.ovh.com/createToken/index.cgi?GET=/domain/zone/example.com/*&PUT=/domain/zone/example.com/*&POST=/domain/zone/example.com/*&DELETE=/domain/zone/example.com/*"""
         parser.add_argument(
             "--auth-entrypoint",
             help="specify the OVH entrypoint",
@@ -90,14 +91,18 @@ class Provider(BaseProvider):
         server_time = self.session.get(f"{self.endpoint_api}/auth/time").json()
         self.time_delta = server_time - int(time.time())
 
-        # Get domain and status
+        # Get domain and status. We query the zone directly instead of listing
+        # all zones, so the token only needs to be granted access to
+        # /domain/zone/{domain}/* rather than the whole /domain/zone/* scope.
         domain = self.domain
 
-        domains = self._get("/domain/zone/")
-        if domain not in domains:
-            raise AuthenticationError(f"Domain {domain} not found")
+        try:
+            status = self._get(f"/domain/zone/{domain}/status")
+        except requests.exceptions.HTTPError as error:
+            if error.response is not None and error.response.status_code == 404:
+                raise AuthenticationError(f"Domain {domain} not found")
+            raise
 
-        status = self._get(f"/domain/zone/{domain}/status")
         if not status["isDeployed"]:
             raise AuthenticationError(f"Zone {domain} is not deployed")
 

--- a/src/lexicon/_private/providers/ovh.py
+++ b/src/lexicon/_private/providers/ovh.py
@@ -157,12 +157,23 @@ class Provider(BaseProvider):
 
         for record_id in record_ids:
             raw = self._get(f"/domain/zone/{domain}/record/{record_id}")
+            target = raw["target"]
+            # OVH returns TXT targets wrapped in double quotes; strip them so
+            # the content is comparable to what callers provide and consistent
+            # with the other Lexicon providers.
+            if (
+                raw["fieldType"] == "TXT"
+                and len(target) >= 2
+                and target.startswith('"')
+                and target.endswith('"')
+            ):
+                target = target[1:-1]
             records.append(
                 {
                     "type": raw["fieldType"],
                     "name": self._full_name(raw["subDomain"]),
                     "ttl": raw["ttl"],
-                    "content": raw["target"],
+                    "content": target,
                     "id": raw["id"],
                 }
             )

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate.yaml
@@ -2,50 +2,99 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723171'}
+    body:
+      string: '1782251799'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:31 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e3.936.6302]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:39 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723171']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251799'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:31 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e3.13694.8759]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:39 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate.yaml
@@ -30,33 +30,6 @@ interactions:
       User-Agent: [python-requests/2.18.4]
       X-Ovh-Timestamp: ['1528723171']
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
-  response:
-    body: {string: '["pacalis.net"]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:31 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e3.14603.1058]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723171']
-    method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
   response:
     body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -2,50 +2,99 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723172'}
+    body:
+      string: '1782251799'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e4.8609.3821]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:39 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251799'
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/thisisadomainidonotown.com/status
   response:
-    body: null
+    body:
+      string: '{"class":"Client::Forbidden","message":"This call has not been granted"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e4.11854.4565]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 404, message: Not Found}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '72'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:39 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 403
+      message: Forbidden
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_authenticate_with_unmanaged_domain_should_fail.yaml
@@ -30,9 +30,9 @@ interactions:
       User-Agent: [python-requests/2.18.4]
       X-Ovh-Timestamp: ['1528723172']
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/thisisadomainidonotown.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body: null
     headers:
       Access-Control-Allow-Origin: ['*']
       Cache-Control: [no-cache]
@@ -47,5 +47,5 @@ interactions:
           be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
           code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
           involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+    status: {code: 404, message: Not Found}
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_A_with_valid_name_and_content.yaml
@@ -2,162 +2,253 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723172'}
+    body:
+      string: '1782251799'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e4.25211.0244]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:39 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251799'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e4.25211.6302]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251800'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=A&subDomain=localhost
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e4.13694.8158]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "A", "subDomain": "localhost", "target": "127.0.0.1", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=A&subDomain=localhost
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e4.936.2745]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "A", "subDomain": "localhost", "target": "127.0.0.1", "ttl":
-      3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['80']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '80'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251800'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"127.0.0.1","ttl":3600,"zone":"pacalis.net","fieldType":"A","id":1553659740,"subDomain":"localhost"}'}
+    body:
+      string: '{"fieldType":"A","id":5420906913,"subDomain":"localhost","target":"127.0.0.1","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e4.14603.7646]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '111'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251800'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76e4.936.9784]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_CNAME_with_valid_name_and_content.yaml
@@ -2,162 +2,253 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723172'}
+    body:
+      string: '1782251800'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e4.31268.7382]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251800'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e4.30656.9320]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251800'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=CNAME&subDomain=docs
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e4.30657.9581]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "CNAME", "subDomain": "docs", "target": "docs.example.com", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=CNAME&subDomain=docs
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e4.31233.8955]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "CNAME", "subDomain": "docs", "target": "docs.example.com",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['86']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '86'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251800'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"docs.example.com","ttl":3600,"zone":"pacalis.net","fieldType":"CNAME","id":1553659741,"subDomain":"docs"}'}
+    body:
+      string: '{"fieldType":"CNAME","id":5420906914,"subDomain":"docs","target":"docs.example.com","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e4.31233.6369]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '117'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:40 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723172']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251800'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:32 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e4.30817.0883]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:41 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_fqdn_name_and_content.yaml
@@ -2,162 +2,253 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723173'}
+    body:
+      string: '1782251802'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e5.31451.6928]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:42 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251802'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e5.31268.9559]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:42 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251802'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.fqdn
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e5.31233.0378]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.fqdn", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.fqdn
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e5.30817.2814]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.fqdn", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['98']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251802'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659742,"subDomain":"_acme-challenge.fqdn"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906919,"subDomain":"_acme-challenge.fqdn","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e5.31268.4930]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '133'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251803'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76e5.31268.4643]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_full_name_and_content.yaml
@@ -2,162 +2,253 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723173'}
+    body:
+      string: '1782251802'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e5.29148.6993]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:42 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251802'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e5.29148.4889]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:42 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251802'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.full
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e5.29309.1761]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:42 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.full", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.full
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e5.8609.3011]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.full", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['98']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251802'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659743,"subDomain":"_acme-challenge.full"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906918,"subDomain":"_acme-challenge.full","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e5.8609.5731]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '133'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:42 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723173']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251802'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:33 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e5.29309.4756]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:42 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_for_TXT_with_valid_name_and_content.yaml
@@ -2,162 +2,253 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723174'}
+    body:
+      string: '1782251801'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76e6.8305.8913]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:41 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251801'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76e6.7982.8647]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:41 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251801'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.test
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76e6.7982.5053]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:41 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.test", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.test
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76e6.8562.0597]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.test", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['98']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251801'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659745,"subDomain":"_acme-challenge.test"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906915,"subDomain":"_acme-challenge.test","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76e6.8343.4028]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '133'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:41 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251801'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76e6.8343.9904]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:41 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_multiple_times_should_create_record_set.yaml
@@ -2,274 +2,459 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723174'}
+    body:
+      string: '1782251818'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e6.12081.7600]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251818'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e6.12081.6872]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251818'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.createrecordset
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e6.31018.5519]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.createrecordset", "target": "challengetoken1", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.createrecordset
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e6.9250.5275]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.createrecordset", "target":
-      "\"challengetoken1\"", "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['110']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251818'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906936,"subDomain":"_acme-challenge.createrecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e6.10429.5882]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:59 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251819'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e6.13072.5994]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:59 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723174']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251819'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.createrecordset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.createrecordset
   response:
-    body: {string: '[1553659750]'}
+    body:
+      string: '[5420906936]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:34 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e6.12081.9423]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:59 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251819'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659750
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906936
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906936,"subDomain":"_acme-challenge.createrecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.22517.7098]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:59 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.createrecordset", "target":
-      "\"challengetoken2\"", "ttl": 3600}'
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.createrecordset", "target": "challengetoken2", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['110']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251819'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659751,"subDomain":"_acme-challenge.createrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906937,"subDomain":"_acme-challenge.createrecordset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.12081.4395]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:59 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251819'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.9250.0042]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:59 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_create_record_with_duplicate_records_should_be_noop.yaml
@@ -2,270 +2,453 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723175'}
+    body:
+      string: '1782251817'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.16371.3525]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251817'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.10429.5335]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:57 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251817'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.noop
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.12081.9588]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.noop", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.noop
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.22517.2398]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.noop", "target": "challengetoken",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['98']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '98'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251817'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659752,"subDomain":"_acme-challenge.noop"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906935,"subDomain":"_acme-challenge.noop","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.9250.8055]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '133'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:57 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251817'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.9250.5686]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251818'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.noop
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.noop
   response:
-    body: {string: '[1553659752]'}
+    body:
+      string: '[5420906935]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.16371.0504]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251818'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659752
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906935
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659752,"subDomain":"_acme-challenge.noop"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906935,"subDomain":"_acme-challenge.noop","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.9250.9202]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '133'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251818'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.noop
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.noop
   response:
-    body: {string: '[1553659752]'}
+    body:
+      string: '[5420906935]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.10429.7957]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723175']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251818'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659752
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906935
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659752,"subDomain":"_acme-challenge.noop"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906935,"subDomain":"_acme-challenge.noop","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:35 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76e7.10429.3575]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '133'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:58 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_should_remove_record.yaml
@@ -2,299 +2,501 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723176'}
+    body:
+      string: '1782251813'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.29148.2789]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:53 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251813'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.8217.0733]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:53 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251813'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfilt
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.8217.0397]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:53 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "delete.testfilt", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfilt
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.8609.2564]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testfilt", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['93']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251813'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659753,"subDomain":"delete.testfilt"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906930,"subDomain":"delete.testfilt","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.8609.3973]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:53 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251813'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.8217.0517]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:53 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251813'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfilt
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfilt
   response:
-    body: {string: '[1553659753]'}
+    body:
+      string: '[5420906930]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.29309.0331]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251814'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659753
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906930
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659753,"subDomain":"delete.testfilt"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906930,"subDomain":"delete.testfilt","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.8217.8277]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251814'
     method: DELETE
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659753
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906930
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.8499.1885]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251814'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.17983.9587]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251814'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfilt
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfilt
   response:
-    body: {string: '[]'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76e8.29148.6582]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_fqdn_name_should_remove_record.yaml
@@ -2,299 +2,501 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723176'}
+    body:
+      string: '1782251816'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:36 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e8.7491.1062]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:56 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723176']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251816'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.13160.2934]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:56 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723177']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251816'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfqdn
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.21796.8070]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:56 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "delete.testfqdn", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723177']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfqdn
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.15874.1748]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testfqdn", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['93']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723177']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251816'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659754,"subDomain":"delete.testfqdn"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906933,"subDomain":"delete.testfqdn","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.7491.6381]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:56 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723177']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251816'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.7491.6545]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:56 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723177']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251816'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfqdn
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfqdn
   response:
-    body: {string: '[1553659754]'}
+    body:
+      string: '[5420906933]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.15874.5708]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:56 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723177']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251816'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659754
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906933
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659754,"subDomain":"delete.testfqdn"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906933,"subDomain":"delete.testfqdn","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.30346.2531]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:56 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723177']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251816'
     method: DELETE
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659754
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906933
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:37 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76e9.15874.9635]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723178']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251817'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:38 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76ea.7491.5304]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723178']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251817'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfqdn
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfqdn
   response:
-    body: {string: '[]'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:38 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-8.5b1e76ea.11422.8710]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:57 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_filter_with_full_name_should_remove_record.yaml
@@ -2,299 +2,501 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723180'}
+    body:
+      string: '1782251814'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.13047.0420]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251814'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.29385.0638]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251814'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfull
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.11854.9830]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:54 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "delete.testfull", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfull
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.29148.7364]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testfull", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['93']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251814'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659759,"subDomain":"delete.testfull"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906931,"subDomain":"delete.testfull","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.30430.1639]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:55 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251815'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.29385.6139]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:55 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251815'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfull
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfull
   response:
-    body: {string: '[1553659759]'}
+    body:
+      string: '[5420906931]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.17983.0417]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:55 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251815'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659759
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906931
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659759,"subDomain":"delete.testfull"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906931,"subDomain":"delete.testfull","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.29385.0688]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:55 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251815'
     method: DELETE
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659759
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906931
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.30430.7387]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:55 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251815'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:40 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ec.8609.6909]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:55 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723180']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251815'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testfull
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testfull
   response:
-    body: {string: '[]'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.15492.1224]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:55 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_by_identifier_should_remove_record.yaml
@@ -2,299 +2,501 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723181'}
+    body:
+      string: '1782251811'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.15492.6081]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251811'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.11854.0046]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:52 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251812'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testid
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.17983.2119]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:52 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "delete.testid", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testid
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.28394.0668]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "delete.testid", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['91']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251812'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659763,"subDomain":"delete.testid"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906929,"subDomain":"delete.testid","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.28394.7690]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '126'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:52 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251812'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.15492.8726]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:52 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251812'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testid
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testid
   response:
-    body: {string: '[1553659763]'}
+    body:
+      string: '[5420906929]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.8609.3002]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:52 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251812'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659763
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906929
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659763,"subDomain":"delete.testid"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906929,"subDomain":"delete.testid","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.11854.7762]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '126'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:52 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251812'
     method: DELETE
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659763
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906929
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.17983.3685]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:52 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251812'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.28394.0888]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:53 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723181']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251813'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=delete.testid
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=delete.testid
   response:
-    body: {string: '[]'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:41 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ed.15492.0608]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:53 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_by_content_should_leave_others_untouched.yaml
@@ -2,465 +2,815 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723182'}
+    body:
+      string: '1782251824'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8400.5755]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251824'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8933.0756]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251824'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8933.6641]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordinset", "target": "challengetoken1", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8305.2535]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordinset",
-      "target": "\"challengetoken1\"", "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['112']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251824'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906950,"subDomain":"_acme-challenge.deleterecordinset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8305.2142]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '147'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251824'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8400.9905]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251824'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
   response:
-    body: {string: '[1553659769]'}
+    body:
+      string: '[5420906950]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8049.8684]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251824'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659769
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906950
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906950,"subDomain":"_acme-challenge.deleterecordinset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8192.3129]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '147'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordinset",
-      "target": "\"challengetoken2\"", "ttl": 3600}'
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordinset", "target": "challengetoken2", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['112']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '112'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251824'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906951,"subDomain":"_acme-challenge.deleterecordinset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.9084.3529]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '147'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:05 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251825'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8049.1198]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:05 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251825'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
   response:
-    body: {string: '[1553659769,1553659771]'}
+    body:
+      string: '[5420906950,5420906951]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8933.0656]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:05 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251825'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659769
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906950
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659769,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906950,"subDomain":"_acme-challenge.deleterecordinset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=89']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8049.3040]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '147'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:05 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251825'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659771
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906951
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906951,"subDomain":"_acme-challenge.deleterecordinset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:42 GMT']
-      Keep-Alive: ['timeout=15, max=88']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ee.8049.7204]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '147'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:05 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723182']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251825'
     method: DELETE
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659769
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906950
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=87']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ef.8049.3434]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:05 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251825'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=86']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ef.8049.5958]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:05 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251825'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordinset
   response:
-    body: {string: '[1553659771]'}
+    body:
+      string: '[5420906951]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=85']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ef.8562.9612]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:06 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251826'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659771
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906951
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906951,"subDomain":"_acme-challenge.deleterecordinset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=84']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-7.5b1e76ef.8933.3316]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '147'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:06 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_delete_record_with_record_set_name_remove_all.yaml
@@ -2,466 +2,813 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723183'}
+    body:
+      string: '1782251821'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ef.30430.6208]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:01 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251821'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ef.17983.1817]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:02 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251822'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ef.17983.4245]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:02 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordset", "target": "challengetoken1", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ef.29148.7863]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordset", "target":
-      "\"challengetoken1\"", "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['110']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251822'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906940,"subDomain":"_acme-challenge.deleterecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:43 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76ef.17983.2645]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:02 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723183']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251822'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.15492.5269]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:02 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251822'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
   response:
-    body: {string: '[1553659798]'}
+    body:
+      string: '[5420906940]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.8609.3899]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:02 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251822'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659798
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906940
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906940,"subDomain":"_acme-challenge.deleterecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.8609.7528]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:02 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordset", "target":
-      "\"challengetoken2\"", "ttl": 3600}'
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.deleterecordset", "target": "challengetoken2", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['110']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251822'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659800,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906941,"subDomain":"_acme-challenge.deleterecordset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.15492.0170]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:02 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251822'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.29148.1163]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:03 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251823'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
   response:
-    body: {string: '[1553659798,1553659800]'}
+    body:
+      string: '[5420906940,5420906941]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.29309.6289]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:03 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251823'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659798
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906940
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659798,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906940,"subDomain":"_acme-challenge.deleterecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=89']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.11854.0608]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:03 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251823'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659800
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906941
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659800,"subDomain":"_acme-challenge.deleterecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906941,"subDomain":"_acme-challenge.deleterecordset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=88']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.30430.0183]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '145'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:03 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251823'
     method: DELETE
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659798
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906940
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=87']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.1649.5752]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:03 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251823'
     method: DELETE
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659800
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906941
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=86']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.11854.7515]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:03 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251823'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=85']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.11854.2897]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:03 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723184']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251823'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.deleterecordset
   response:
-    body: {string: '[]'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:44 GMT']
-      Keep-Alive: ['timeout=15, max=84']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f0.11854.9408]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:04 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_after_setting_ttl.yaml
@@ -2,216 +2,353 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723185'}
+    body:
+      string: '1782251806'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.16510.8706]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251806'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.14603.0976]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251806'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=ttl.fqdn
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.18557.2651]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "ttl.fqdn", "target": "ttlshouldbe3600", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=ttl.fqdn
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.25139.4458]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "ttl.fqdn", "target": "ttlshouldbe3600",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['87']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '87'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251806'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"ttlshouldbe3600","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659805,"subDomain":"ttl.fqdn"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906923,"subDomain":"ttl.fqdn","target":"\"ttlshouldbe3600\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.14603.8863]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '122'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251806'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.31576.0838]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251806'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=ttl.fqdn
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=ttl.fqdn
   response:
-    body: {string: '[1553659805]'}
+    body:
+      string: '[5420906923]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.25139.8942]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251806'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659805
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906923
   response:
-    body: {string: '{"target":"ttlshouldbe3600","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659805,"subDomain":"ttl.fqdn"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906923,"subDomain":"ttl.fqdn","target":"\"ttlshouldbe3600\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76f1.18557.2559]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '122'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_should_handle_record_sets.yaml
@@ -2,355 +2,615 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723185'}
+    body:
+      string: '1782251820'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f1.31268.5826]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251820'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f1.31268.9086]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251820'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.listrecordset
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f1.30740.8372]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.listrecordset", "target": "challengetoken1", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.listrecordset
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f1.31444.7714]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.listrecordset", "target":
-      "\"challengetoken1\"", "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251820'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906938,"subDomain":"_acme-challenge.listrecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f1.31221.3222]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '143'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723185']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251820'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:45 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f1.30676.9659]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723186']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251820'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.listrecordset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.listrecordset
   response:
-    body: {string: '[1553659826]'}
+    body:
+      string: '[5420906938]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:46 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f2.30676.1446]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723186']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251820'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659826
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906938
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906938,"subDomain":"_acme-challenge.listrecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:46 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f2.31233.6906]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '143'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:01 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.listrecordset", "target":
-      "\"challengetoken2\"", "ttl": 3600}'
+    body: '{"fieldType": "TXT", "subDomain": "_acme-challenge.listrecordset", "target": "challengetoken2", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['108']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723186']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '108'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251821'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906939,"subDomain":"_acme-challenge.listrecordset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:46 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f2.31221.1149]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '143'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:01 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723186']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251821'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:46 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f2.31451.3878]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:01 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723186']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251821'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=_acme-challenge.listrecordset
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=_acme-challenge.listrecordset
   response:
-    body: {string: '[1553659826,1553659832]'}
+    body:
+      string: '[5420906938,5420906939]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:46 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f2.31268.0370]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '23'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:01 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723186']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251821'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659826
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906938
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906938,"subDomain":"_acme-challenge.listrecordset","target":"\"challengetoken1\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:46 GMT']
-      Keep-Alive: ['timeout=15, max=89']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f2.31233.1266]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '143'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:01 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723186']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251821'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659832
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906939
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906939,"subDomain":"_acme-challenge.listrecordset","target":"\"challengetoken2\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:46 GMT']
-      Keep-Alive: ['timeout=15, max=88']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f2.31221.8772]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '143'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:01 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_fqdn_name_filter_should_return_record.yaml
@@ -2,216 +2,353 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723187'}
+    body:
+      string: '1782251805'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.21960.0037]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:45 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251805'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.14618.1816]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:45 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251805'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=random.fqdntest
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.6546.2513]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:45 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "random.fqdntest", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=random.fqdntest
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.6546.3251]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "random.fqdntest", "target": "challengetoken",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['93']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251805'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659838,"subDomain":"random.fqdntest"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906922,"subDomain":"random.fqdntest","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.3759.3815]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:45 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251805'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.6546.4481]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:45 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251805'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=random.fqdntest
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=random.fqdntest
   response:
-    body: {string: '[1553659838]'}
+    body:
+      string: '[5420906922]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.12965.5350]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251806'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659838
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906922
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659838,"subDomain":"random.fqdntest"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906922,"subDomain":"random.fqdntest","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-2.5b1e76f3.12965.2415]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:46 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_full_name_filter_should_return_record.yaml
@@ -2,216 +2,353 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723187'}
+    body:
+      string: '1782251804'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f3.24403.0713]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251804'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f3.22517.3585]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251804'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=random.fulltest
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f3.22517.5192]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "random.fulltest", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=random.fulltest
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f3.31018.5823]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "random.fulltest", "target": "challengetoken",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['93']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723187']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251804'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659860,"subDomain":"random.fulltest"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906921,"subDomain":"random.fulltest","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:47 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f3.24403.6352]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251804'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f4.13072.2959]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251804'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=random.fulltest
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=random.fulltest
   response:
-    body: {string: '[1553659860]'}
+    body:
+      string: '[5420906921]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f4.31018.9229]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251804'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659860
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906921
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659860,"subDomain":"random.fulltest"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906921,"subDomain":"random.fulltest","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-6.5b1e76f4.13072.5649]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '128'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:45 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_invalid_filter_should_be_empty_list.yaml
@@ -2,104 +2,147 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723188'}
+    body:
+      string: '1782251819'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.29148.0684]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:59 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251819'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.14274.9829]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251820'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=filter.thisdoesnotexist
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.30430.8425]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=filter.thisdoesnotexist
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.14274.4750]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:57:00 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_name_filter_should_return_record.yaml
@@ -2,216 +2,353 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723188'}
+    body:
+      string: '1782251803'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.29148.2017]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251803'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.11854.5411]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251803'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=random.test
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.11854.8620]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "random.test", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=random.test
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.30430.0700]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "random.test", "target": "challengetoken",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['89']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '89'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251803'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659867,"subDomain":"random.test"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906920,"subDomain":"random.test","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.30430.6148]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '124'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251803'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:48 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f4.29148.2243]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:43 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723188']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251803'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=random.test
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=random.test
   response:
-    body: {string: '[1553659867]'}
+    body:
+      string: '[5420906920]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.14274.5664]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251804'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659867
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906920
   response:
-    body: {string: '{"target":"challengetoken","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659867,"subDomain":"random.test"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906920,"subDomain":"random.test","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.29148.8583]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '124'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:44 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_list_records_with_no_arguments_should_list_all.yaml
@@ -2,725 +2,1077 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723189'}
+    body:
+      string: '1528723189'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.8217.6088]
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=100
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
     uri: https://eu.api.ovh.com/1.0/domain/zone/
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '["example.com"]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.29148.5306]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=99
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '{"warnings":null,"errors":null,"isDeployed":true}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.28394.8366]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=98
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '[1553644693,1553644694,1553644697,1553644695,1553659740,1553659741,1553644696,1553644690,1553659838,1553659860,1553659867,1553659805,1553644691,1553644692,1553659750,1553659751,1553659771,1553659742,1553659743,1553659826,1553659832,1553659752,1553659745]'}
+    body:
+      string: '[1553644693,1553644694,1553644697,1553644695,1553659740,1553659741,1553644696,1553644690,1553659838,1553659860,1553659867,1553659805,1553644691,1553644692,1553659750,1553659751,1553659771,1553659742,1553659743,1553659826,1553659832,1553659752,1553659745]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.29148.6415]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=97
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644693
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644693
   response:
-    body: {string: '{"target":"dns103.ovh.net.","ttl":0,"zone":"pacalis.net","fieldType":"NS","id":1553644693,"subDomain":""}'}
+    body:
+      string: '{"target":"dns103.ovh.net.","ttl":0,"zone":"example.com","fieldType":"NS","id":1553644693,"subDomain":""}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.1649.1591]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=96
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644694
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644694
   response:
-    body: {string: '{"target":"ns103.ovh.net.","ttl":0,"zone":"pacalis.net","fieldType":"NS","id":1553644694,"subDomain":""}'}
+    body:
+      string: '{"target":"ns103.ovh.net.","ttl":0,"zone":"example.com","fieldType":"NS","id":1553644694,"subDomain":""}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.14274.2553]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=95
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644697
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644697
   response:
-    body: {string: '{"target":"1 redirect.ovh.net.","ttl":0,"zone":"pacalis.net","fieldType":"MX","id":1553644697,"subDomain":""}'}
+    body:
+      string: '{"target":"1 redirect.ovh.net.","ttl":0,"zone":"example.com","fieldType":"MX","id":1553644697,"subDomain":""}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.1649.3672]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=94
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644695
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644695
   response:
-    body: {string: '{"target":"213.186.33.5","ttl":0,"zone":"pacalis.net","fieldType":"A","id":1553644695,"subDomain":""}'}
+    body:
+      string: '{"target":"213.186.33.5","ttl":0,"zone":"example.com","fieldType":"A","id":1553644695,"subDomain":""}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.1649.2965]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=93
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659740
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659740
   response:
-    body: {string: '{"target":"127.0.0.1","ttl":3600,"zone":"pacalis.net","fieldType":"A","id":1553659740,"subDomain":"localhost"}'}
+    body:
+      string: '{"target":"127.0.0.1","ttl":3600,"zone":"example.com","fieldType":"A","id":1553659740,"subDomain":"localhost"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.14274.3905]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=92
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659741
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659741
   response:
-    body: {string: '{"target":"docs.example.com","ttl":3600,"zone":"pacalis.net","fieldType":"CNAME","id":1553659741,"subDomain":"docs"}'}
+    body:
+      string: '{"target":"docs.example.com","ttl":3600,"zone":"example.com","fieldType":"CNAME","id":1553659741,"subDomain":"docs"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.15492.9532]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=91
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644696
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644696
   response:
-    body: {string: '{"target":"pacalis.net.","ttl":0,"zone":"pacalis.net","fieldType":"CNAME","id":1553644696,"subDomain":"www"}'}
+    body:
+      string: '{"target":"example.com.","ttl":0,"zone":"example.com","fieldType":"CNAME","id":1553644696,"subDomain":"www"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:49 GMT']
-      Keep-Alive: ['timeout=15, max=90']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f5.15492.0822]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:49 GMT
+      Keep-Alive:
+      - timeout=15, max=90
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723189']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723189'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644690
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644690
   response:
-    body: {string: '{"target":"\"1|www.pacalis.net\"","ttl":0,"zone":"pacalis.net","fieldType":"TXT","id":1553644690,"subDomain":""}'}
+    body:
+      string: '{"target":"\"1|www.example.com\"","ttl":0,"zone":"example.com","fieldType":"TXT","id":1553644690,"subDomain":""}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:50 GMT']
-      Keep-Alive: ['timeout=15, max=89']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f6.8609.0915]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:50 GMT
+      Keep-Alive:
+      - timeout=15, max=89
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723190']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723190'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659838
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659838
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659838,"subDomain":"random.fqdntest"}'}
+    body:
+      string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659838,"subDomain":"random.fqdntest"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:50 GMT']
-      Keep-Alive: ['timeout=15, max=88']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f6.11854.7328]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:50 GMT
+      Keep-Alive:
+      - timeout=15, max=88
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723190']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723190'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659860
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659860
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659860,"subDomain":"random.fulltest"}'}
+    body:
+      string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659860,"subDomain":"random.fulltest"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=87']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.8609.1569]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=87
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659867
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659867
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659867,"subDomain":"random.test"}'}
+    body:
+      string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659867,"subDomain":"random.test"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=86']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.11854.4292]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=86
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659805
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659805
   response:
-    body: {string: '{"target":"ttlshouldbe3600","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659805,"subDomain":"ttl.fqdn"}'}
+    body:
+      string: '{"target":"ttlshouldbe3600","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659805,"subDomain":"ttl.fqdn"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=85']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.15492.0720]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=85
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644691
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644691
   response:
-    body: {string: '{"target":"\"3|welcome\"","ttl":0,"zone":"pacalis.net","fieldType":"TXT","id":1553644691,"subDomain":"www"}'}
+    body:
+      string: '{"target":"\"3|welcome\"","ttl":0,"zone":"example.com","fieldType":"TXT","id":1553644691,"subDomain":"www"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=84']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.28394.9604]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=84
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553644692
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553644692
   response:
-    body: {string: '{"target":"\"l|fr\"","ttl":0,"zone":"pacalis.net","fieldType":"TXT","id":1553644692,"subDomain":"www"}'}
+    body:
+      string: '{"target":"\"l|fr\"","ttl":0,"zone":"example.com","fieldType":"TXT","id":1553644692,"subDomain":"www"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=83']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.17983.0213]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=83
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659750
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659750
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'}
+    body:
+      string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659750,"subDomain":"_acme-challenge.createrecordset"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=82']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.28394.2474]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=82
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659751
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659751
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659751,"subDomain":"_acme-challenge.createrecordset"}'}
+    body:
+      string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659751,"subDomain":"_acme-challenge.createrecordset"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=81']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.29309.7695]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=81
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659771
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659771
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'}
+    body:
+      string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659771,"subDomain":"_acme-challenge.deleterecordinset"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=80']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.28394.0290]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=80
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659742
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659742
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659742,"subDomain":"_acme-challenge.fqdn"}'}
+    body:
+      string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659742,"subDomain":"_acme-challenge.fqdn"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=79']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.29309.1295]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=79
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659743
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659743
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659743,"subDomain":"_acme-challenge.full"}'}
+    body:
+      string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659743,"subDomain":"_acme-challenge.full"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=78']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.17983.9814]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=78
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659826
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659826
   response:
-    body: {string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'}
+    body:
+      string: '{"target":"\"challengetoken1\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659826,"subDomain":"_acme-challenge.listrecordset"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:51 GMT']
-      Keep-Alive: ['timeout=15, max=77']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f7.28394.4817]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:51 GMT
+      Keep-Alive:
+      - timeout=15, max=77
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723191']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723191'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659832
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659832
   response:
-    body: {string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'}
+    body:
+      string: '{"target":"\"challengetoken2\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659832,"subDomain":"_acme-challenge.listrecordset"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=76']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f8.29148.0012]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:52 GMT
+      Keep-Alive:
+      - timeout=15, max=76
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723192'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659752
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659752
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659752,"subDomain":"_acme-challenge.noop"}'}
+    body:
+      string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659752,"subDomain":"_acme-challenge.noop"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=75']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f8.29309.1214]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:52 GMT
+      Keep-Alive:
+      - timeout=15, max=75
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.18.4
+      X-Ovh-Timestamp:
+      - '1528723192'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659745
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/1553659745
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659745,"subDomain":"_acme-challenge.test"}'}
+    body:
+      string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"example.com","fieldType":"TXT","id":1553659745,"subDomain":"_acme-challenge.test"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=74']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76f8.15492.2774]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 11 Jun 2018 13:19:52 GMT
+      Keep-Alive:
+      - timeout=15, max=74
+      Server:
+      - Apache
+      Transfer-Encoding:
+      - chunked
+      X-RECRUITMENT:
+      - You know how to code? This is a good start, but it may not be enough! We are looking for engineers who LOVE coding. Programming enthusiasts, code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate, involved. You want to challenge yourself? Join us! http://ovh.jobs
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record.yaml
@@ -2,273 +2,455 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723192'}
+    body:
+      string: '1782251807'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f8.1340.5617]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251807'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f8.983.1230]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251807'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.test
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f8.983.2550]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "orig.test", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.test
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f8.891.7444]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.test", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['87']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '87'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251807'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659879,"subDomain":"orig.test"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906924,"subDomain":"orig.test","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f8.1466.2123]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '122'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251807'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f8.1390.7707]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251807'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.test
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.test
   response:
-    body: {string: '[1553659879]'}
+    body:
+      string: '[5420906924]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:52 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f8.1340.2239]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723192']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251807'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659879
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906924
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659879,"subDomain":"orig.test"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906924,"subDomain":"orig.test","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f9.1466.3245]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '122'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:47 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"subDomain": "updated.test", "target": "\"challengetoken\""}'
+    body: '{"subDomain": "updated.test", "target": "challengetoken"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['57']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723193']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '57'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251807'
     method: PUT
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659879
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906924
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f9.1466.2947]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:48 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723193']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251808'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-3.5b1e76f9.983.0050]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:48 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_should_modify_record_name_specified.yaml
@@ -2,273 +2,455 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723193'}
+    body:
+      string: '1782251808'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f9.30817.6486]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:48 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723193']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251808'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f9.30817.6533]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:48 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723193']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251808'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.nameonly.test
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f9.31451.1650]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:48 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "orig.nameonly.test", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723193']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.nameonly.test
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f9.30754.3455]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.nameonly.test", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['96']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723193']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '96'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251808'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659905,"subDomain":"orig.nameonly.test"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906925,"subDomain":"orig.nameonly.test","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f9.30754.6027]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '131'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:48 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723193']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251808'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:53 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76f9.31221.8305]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:48 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251808'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.nameonly.test
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.nameonly.test
   response:
-    body: {string: '[1553659905]'}
+    body:
+      string: '[5420906925]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76fa.30754.8982]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251809'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659905
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906925
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659905,"subDomain":"orig.nameonly.test"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906925,"subDomain":"orig.nameonly.test","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76fa.31451.3665]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '131'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: '{"subDomain": "orig.nameonly.test", "target": "updated"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['56']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '56'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251809'
     method: PUT
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659905
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906925
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76fa.31136.6786]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251809'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-5.5b1e76fa.30754.8660]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_fqdn_name_should_modify_record.yaml
@@ -2,273 +2,455 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723194'}
+    body:
+      string: '1782251810'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fa.28394.5411]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:50 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251810'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fa.15492.2594]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:50 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251810'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.testfqdn
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fa.14274.1075]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "orig.testfqdn", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.testfqdn
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fa.30430.0791]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.testfqdn", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['91']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251811'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659909,"subDomain":"orig.testfqdn"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906927,"subDomain":"orig.testfqdn","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fa.30219.0063]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '126'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251811'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fa.8609.9921]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723194']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251811'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.testfqdn
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.testfqdn
   response:
-    body: {string: '[1553659909]'}
+    body:
+      string: '[5420906927]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:54 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fa.29309.0693]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251811'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659909
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906927
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659909,"subDomain":"orig.testfqdn"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906927,"subDomain":"orig.testfqdn","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fb.30430.5797]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '126'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"subDomain": "updated.testfqdn", "target": "\"challengetoken\""}'
+    body: '{"subDomain": "updated.testfqdn", "target": "challengetoken"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['61']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251811'
     method: PUT
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659909
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906927
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fb.28394.1086]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251811'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-1.5b1e76fb.28394.2781]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:51 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
+++ b/tests/fixtures/cassettes/ovh/IntegrationTests/test_provider_when_calling_update_record_with_full_name_should_modify_record.yaml
@@ -2,273 +2,455 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
     method: GET
     uri: https://eu.api.ovh.com/1.0/auth/time
   response:
-    body: {string: '1528723195'}
+    body:
+      string: '1782251809'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=100']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fb.936.6427]
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '10'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251809'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/status
   response:
-    body: {string: '["pacalis.net"]'}
+    body:
+      string: '{"errors":[],"isDeployed":true,"warnings":[]}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=99']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fb.936.1200]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '94'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251809'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/status
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.testfull
   response:
-    body: {string: '{"warnings":null,"errors":null,"isDeployed":true}'}
+    body:
+      string: '[]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=98']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fb.936.5886]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '2'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: null
+    body: '{"fieldType": "TXT", "subDomain": "orig.testfull", "target": "challengetoken", "ttl": 3600}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
-    method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.testfull
-  response:
-    body: {string: '[]'}
-    headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=97']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fb.936.2545]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
-- request:
-    body: '{"fieldType": "TXT", "subDomain": "orig.testfull", "target": "\"challengetoken\"",
-      "ttl": 3600}'
-    headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['91']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251809'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659914,"subDomain":"orig.testfull"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906926,"subDomain":"orig.testfull","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:55 GMT']
-      Keep-Alive: ['timeout=15, max=96']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fb.936.1420]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '126'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:49 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723195']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251809'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:56 GMT']
-      Keep-Alive: ['timeout=15, max=95']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fc.936.8414]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:50 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723196']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251810'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record?fieldType=TXT&subDomain=orig.testfull
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record?fieldType=TXT&subDomain=orig.testfull
   response:
-    body: {string: '[1553659914]'}
+    body:
+      string: '[5420906926]'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:56 GMT']
-      Keep-Alive: ['timeout=15, max=94']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fc.14603.9770]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - GET, POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '12'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:50 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723196']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251810'
     method: GET
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659914
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906926
   response:
-    body: {string: '{"target":"\"challengetoken\"","ttl":3600,"zone":"pacalis.net","fieldType":"TXT","id":1553659914,"subDomain":"orig.testfull"}'}
+    body:
+      string: '{"fieldType":"TXT","id":5420906926,"subDomain":"orig.testfull","target":"\"challengetoken\"","ttl":3600,"zone":"example.com"}'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:56 GMT']
-      Keep-Alive: ['timeout=15, max=93']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fc.936.6181]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '126'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:50 GMT
+      server:
+      - nginx
+      transfer-encoding:
+      - chunked
+      vary:
+      - Accept-Encoding
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: '{"subDomain": "updated.testfull", "target": "\"challengetoken\""}'
+    body: '{"subDomain": "updated.testfull", "target": "challengetoken"}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['61']
-      Content-type: [application/json]
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723196']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '61'
+      Content-type:
+      - application/json
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251810'
     method: PUT
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/record/1553659914
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/record/5420906926
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:56 GMT']
-      Keep-Alive: ['timeout=15, max=92']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fc.936.7827]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - DELETE, GET, PUT
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:50 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      User-Agent: [python-requests/2.18.4]
-      X-Ovh-Timestamp: ['1528723196']
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.34.2
+      X-Ovh-Timestamp:
+      - '1782251810'
     method: POST
-    uri: https://eu.api.ovh.com/1.0/domain/zone/pacalis.net/refresh
+    uri: https://eu.api.ovh.com/1.0/domain/zone/example.com/refresh
   response:
-    body: {string: 'null'}
+    body:
+      string: 'null'
     headers:
-      Access-Control-Allow-Origin: ['*']
-      Cache-Control: [no-cache]
-      Connection: [Keep-Alive]
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 11 Jun 2018 13:19:56 GMT']
-      Keep-Alive: ['timeout=15, max=91']
-      Server: [Apache]
-      Transfer-Encoding: [chunked]
-      X-OVH-QUERYID: [FR.ws-4.5b1e76fc.936.5297]
-      X-RECRUITMENT: ['You know how to code? This is a good start, but it may not
-          be enough! We are looking for engineers who LOVE coding. Programming enthusiasts,
-          code aesthetes, CTF winners, ... In short, geeks eager to learn, obstinate,
-          involved. You want to challenge yourself? Join us! http://ovh.jobs']
-    status: {code: 200, message: OK}
+      access-control-allow-headers:
+      - X-Ovh-Timestamp, X-Ovh-Consumer, X-Ovh-Application, X-Ovh-Signature, X-Ovh-Session, Authorization, Content-Type, X-Challenge-Response, X-Challenge-Payload, User-Agent
+      access-control-allow-methods:
+      - POST
+      access-control-allow-origin:
+      - '*'
+      access-control-expose-headers:
+      - X-Pagination-Cursor-Next, X-Ovh-Queryid
+      access-control-max-age:
+      - '60'
+      cache-control:
+      - no-cache, no-store
+      content-length:
+      - '4'
+      content-type:
+      - application/json; charset=utf-8
+      date:
+      - Tue, 23 Jun 2026 21:56:50 GMT
+      server:
+      - nginx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/providers/test_ovh.py
+++ b/tests/providers/test_ovh.py
@@ -15,7 +15,7 @@ class TestOvhProvider(IntegrationTestsV2):
     # Default domain matches the recorded cassettes. Override with the
     # LEXICON_OVH_DOMAIN environment variable to run live tests
     # (LEXICON_LIVE_TESTS=true) against a domain you actually own.
-    domain = os.environ.get("LEXICON_OVH_DOMAIN", "pacalis.net")
+    domain = os.environ.get("LEXICON_OVH_DOMAIN", "example.com")
 
     def _filter_headers(self):
         return ["X-Ovh-Application", "X-Ovh-Consumer", "X-Ovh-Signature"]

--- a/tests/providers/test_ovh.py
+++ b/tests/providers/test_ovh.py
@@ -1,5 +1,7 @@
 """Integration tests for OVH"""
 
+import os
+
 from integration_tests import IntegrationTestsV2
 
 
@@ -10,7 +12,10 @@ class TestOvhProvider(IntegrationTestsV2):
     """TestCase for OVH"""
 
     provider_name = "ovh"
-    domain = "pacalis.net"
+    # Default domain matches the recorded cassettes. Override with the
+    # LEXICON_OVH_DOMAIN environment variable to run live tests
+    # (LEXICON_LIVE_TESTS=true) against a domain you actually own.
+    domain = os.environ.get("LEXICON_OVH_DOMAIN", "pacalis.net")
 
     def _filter_headers(self):
         return ["X-Ovh-Application", "X-Ovh-Consumer", "X-Ovh-Signature"]


### PR DESCRIPTION
Hello,

Two small OVH changes:

1. Reduced the required API permissions: I removed the unnecessary GET to "/domain/zone/" since "/domain/zone/{domain}/status" is sufficient to validate the zone. This avoids granting the broad /domain/zone/* scope, and as a side benefit improves performance on accounts with many domains.

2. Strip the surrounding double quotes the OVH API adds to TXT record targets, like several other providers already do. This fixes duplicate-record detection on create_record.

Best regards,
Merwan