### PR TITLE
Fix porkbun provider rejecting MX and SRV records with HTTP 400 (priority not split into prio field)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## master - CURRENT
+### Modified
+* Fix `porkbun` provider rejecting MX and SRV records with HTTP 400 Bad Request, by splitting the inline priority out of the record content into Porkbun's dedicated `prio` field
 
 ## 3.25.2 - 10/05/2026
 ### Added

--- a/src/lexicon/_private/providers/porkbun.py
+++ b/src/lexicon/_private/providers/porkbun.py
@@ -69,8 +69,18 @@ class Provider(BaseProvider):
             "name": self._relative_name(name),
         }
 
-        if self._get_lexicon_option("priority"):
-            data["prio"] = self._get_lexicon_option("priority")
+        priority = self._get_lexicon_option("priority")
+        # Porkbun expects the record priority in a dedicated "prio" field. For MX and
+        # SRV the RDATA arrives with the priority prefixed inline (e.g. "10 mail." or
+        # "0 5 5223 xmpp.example.com."); split it out here, otherwise Porkbun rejects
+        # the create/edit with HTTP 400 Bad Request.
+        if priority is None and rtype in ("MX", "SRV"):
+            first, _, rest = content.partition(" ")
+            if rest and first.isdigit():
+                priority = first
+                data["content"] = rest
+        if priority:
+            data["prio"] = priority
 
         if self._get_lexicon_option("ttl"):
             data["ttl"] = self._get_lexicon_option("ttl")
@@ -131,8 +141,18 @@ class Provider(BaseProvider):
         if self._get_lexicon_option("ttl"):
             data["ttl"] = self._get_lexicon_option("ttl")
 
-        if self._get_lexicon_option("priority"):
-            data["prio"] = self._get_lexicon_option("priority")
+        priority = self._get_lexicon_option("priority")
+        # Porkbun expects the record priority in a dedicated "prio" field. For MX and
+        # SRV the RDATA arrives with the priority prefixed inline (e.g. "10 mail." or
+        # "0 5 5223 xmpp.example.com."); split it out here, otherwise Porkbun rejects
+        # the create/edit with HTTP 400 Bad Request.
+        if priority is None and rtype in ("MX", "SRV"):
+            first, _, rest = content.partition(" ")
+            if rest and first.isdigit():
+                priority = first
+                data["content"] = rest
+        if priority:
+            data["prio"] = priority
 
         result = self._post(endpoint, data)
 


### PR DESCRIPTION
### Problem

The `porkbun` provider fails to create/update **MX** and **SRV** records — Porkbun's API returns `400 Bad Request` for every one, while A/AAAA/CNAME/TXT work fine.

Porkbun's `dns/create` and `dns/edit` endpoints expect the record **priority in a dedicated `prio` field**, with `content` holding only the remainder:
- SRV: `content = "<weight> <port> <target>"`, `prio = <priority>`
- MX:  `content = "<mailhost>"`, `prio = <priority>`

But `create_record`/`update_record` only set `prio` when an explicit `priority` lexicon option is passed. Callers that follow the common convention of putting the whole RDATA in `content` (priority inline, e.g. `"0 5 5223 xmpp.example.com."` or `"10 mail.example.com."`) end up sending a 4-field (SRV) / 2-field (MX) `content` and no `prio`, which Porkbun rejects with `400`.

### Fix

In `create_record` and `update_record`, when `rtype in ("MX", "SRV")` and no explicit `priority` option is given, split the leading integer out of `content` into `prio` (leaving `content` as the remainder). Records that *do* pass an explicit `priority` option are unaffected.

### Validation

Reproduced and confirmed against the live Porkbun API:
- **Before:** `content="0 5 5223 target."` → `400 Bad Request` on `dns/create`.
- **After / equivalent direct call:** `content="5 5223 target."` + `prio="0"` → `SUCCESS`; the SRV resolves correctly as `0 5 5223 target.`.

Same behaviour confirmed for MX. I validated the split by driving the Porkbun API directly with both payload shapes; happy to add a recorded cassette test if you'd like — the existing `tests/fixtures/cassettes/porkbun` suite doesn't currently cover MX/SRV.

Downstream report that surfaced this (YunoHost `domain dns push` to Porkbun): https://github.com/YunoHost/issues/issues/2830
